### PR TITLE
Add allowGetAllResources flag to spire-integration-operator and intents-operator

### DIFF
--- a/intents-operator/templates/watcher-clusterrole.yaml
+++ b/intents-operator/templates/watcher-clusterrole.yaml
@@ -34,3 +34,11 @@ rules:
       - get
       - list
       - watch
+{{ if .Values.allowGetAllResources }}
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - 'get'
+{{ end }}

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -32,3 +32,9 @@ watcher:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+# allowGetAllResources gives get permission to watch on all resources. If disabled, the operator will only
+# be able to resolve pods up to their built-in owners. For example, a Pod is owned by a ReplicaSet that is owned by a Deployment.
+# If that Deployment is owned by a custom resource, the operator will not be able to resolve it.
+# For this resolving to be successful, the operator needs to be able to `get` all resources.
+allowGetAllResources: true

--- a/spire-integration-operator/templates/spire-integration-operator-manager-clusterrole.yaml
+++ b/spire-integration-operator/templates/spire-integration-operator-manager-clusterrole.yaml
@@ -35,3 +35,11 @@ rules:
   - get
   - list
   - watch
+{{ if .Values.allowGetAllResources }}
+- apiGroups:
+    - '*'
+  resources:
+    - '*'
+  verbs:
+    - 'get'
+{{ end }}

--- a/spire-integration-operator/values.yaml
+++ b/spire-integration-operator/values.yaml
@@ -22,3 +22,10 @@ spire:
 global:
   spire:
     serverServiceName:
+
+
+# allowGetAllResources gives get permission to watch on all resources. If disabled, the operator will only
+# be able to resolve pods up to their built-in owners. For example, a Pod is owned by a ReplicaSet that is owned by a Deployment.
+# If that Deployment is owned by a custom resource, the operator will not be able to resolve it.
+# For this resolving to be successful, the operator needs to be able to `get` all resources.
+allowGetAllResources: true


### PR DESCRIPTION
## Description
Add allowGetAllResources flag to spire-integration-operator and intents-operator. This is required to support service name resolution for resources owned by custom resources. 

## Link to Dev Task
https://www.notion.so/otterize/Make-algorithm-for-resolving-service-name-the-same-in-SPIRE-operator-intents-operator-and-k8s-sniff-75ef5834eab2401da4a3538c896aaab8
