### PR TITLE
Remove username mapping from kafkaserverconfigs CRD

### DIFF
--- a/intents-operator/templates/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/templates/kafkaserverconfigs-customresourcedefinition.yaml
@@ -65,8 +65,6 @@ spec:
                       - topic
                     type: object
                   type: array
-                usernameMapping:
-                  type: string
               required:
                 - tls
               type: object


### PR DESCRIPTION

## Description
Remove username mapping from kafkaserverconfigs CRD


## Link to Dev Task
https://www.notion.so/otterize/Change-kafka-server-config-UsernameMapping-into-UsernameMappingOverride-add-default-UsernameMappin-f2dc0ceb9b914884adb9812c9e0b4dae