### PR TITLE
Update tls-secret-name annotation

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
         {{- if .Values.operator.autoGenerateTLSUsingSpireIntegration }}
         otterize/service-name: intents-operator
-        otterize/tls-secret-name: intents-operator-spifferize-tls-controller-manager
+        spire-integration.otterize.com/tls-secret-name: intents-operator-spifferize-tls-controller-manager
         {{- end }}
       labels:
         app: intents-operator


### PR DESCRIPTION
## Description
Update tls-secret-name annotation after https://github.com/otterize/spire-integration-operator/pull/31


## Link to Dev Task
https://www.notion.so/otterize/organize-different-otterize-labels-and-annotations-and-set-distinct-prefixes-by-the-operator-that-b64618d0eb7b47e0a44a44d8b455fc06
