### PR TITLE
Move spire-integration-operator to otterize repo

### DIFF
--- a/spire-integration-operator/values.yaml
+++ b/spire-integration-operator/values.yaml
@@ -1,6 +1,6 @@
 operator:
   image:
-    repository: 353146681200.dkr.ecr.us-east-1.amazonaws.com/otterize-tools:spire-integration-operator-latest
+    repository: 353146681200.dkr.ecr.us-east-1.amazonaws.com/otterize:spire-integration-operator-latest
     pullPolicy: Always
 
 resources: { }


### PR DESCRIPTION
## Description
Move spire-integration-operator to otterize repo following https://github.com/otterize/spire-integration-operator/pull/34


## Link to Dev Task
https://www.notion.so/otterize/Add-build-step-for-spire-integration-operator-a6c3aedd159c4c728a8c38b5e5e21d5e
