### PR TITLE
Move Kafka TLS config to operator config

### DIFF
--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "otterize.operator.tlsPath" -}}
+/etc/otterize-spire
+{{- end -}}
+
+{{- define "otterize.operator.cert" -}}
+{{ template "otterize.operator.tlsPath" }}/svid.pem
+{{- end -}}
+
+{{- define "otterize.operator.key" -}}
+{{ template "otterize.operator.tlsPath" }}/key.pem
+{{- end -}}
+
+{{- define "otterize.operator.ca" -}}
+{{ template "otterize.operator.tlsPath" }}/bundle.pem
+{{- end -}}

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -35,6 +35,11 @@ spec:
         {{- range .Values.watchedNamespaces }}
         - --watched-namespaces={{ . | quote }}
         {{- end }}
+        {{- if .Values.operator.autoGenerateTLSUsingSpireIntegration }}
+        - --kafka-server-tls-cert={{ template "otterize.operator.cert" }}
+        - --kafka-server-tls-key={{ template "otterize.operator.key" }}
+        - --kafka-server-tls-ca={{ template "otterize.operator.ca" }}
+        {{ end }}
         command:
         - /manager
         image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ .Values.operator.tag }}"
@@ -78,7 +83,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
         {{- if .Values.operator.autoGenerateTLSUsingSpireIntegration }}
-        - mountPath: /etc/otterize-spire
+        - mountPath: {{ template "otterize.operator.tlsPath" }}
           name: spire-tls
           readOnly: true
         {{- end }}

--- a/intents-operator/templates/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/templates/kafkaserverconfigs-customresourcedefinition.yaml
@@ -59,6 +59,10 @@ spec:
                     rootCAFile:
                       type: string
                   type: object
+                  required:
+                    - certFile
+                    - keyFile
+                    - rootCAFile
                 topics:
                   items:
                     properties:
@@ -77,8 +81,6 @@ spec:
                       - topic
                     type: object
                   type: array
-              required:
-                - tls
               type: object
             status:
               description: KafkaServerConfigStatus defines the observed state of KafkaServerConfig


### PR DESCRIPTION
## Description
TLS files configuration is unique per every instance of intents operator, so no reason for it to be duplicated per each instance of KfakaServerConfig.

Therfore this commit move tls config from kafka server config to the operator configuration.


## Link to Dev Task
[Simplify KafkaServerConfig default config. 
](https://www.notion.so/otterize/Simplify-KafkaServerConfig-default-config-8433c1aded0e4e8da116efa008a5998d)