### PR TITLE
Saving the network mapper state into a config map for persistency

### DIFF
--- a/network-mapper/templates/_helpers.tpl
+++ b/network-mapper/templates/_helpers.tpl
@@ -4,6 +4,9 @@ otterize-network-sniffer
 {{- define "otterize.mapper.fullName" -}}
 otterize-network-mapper
 {{- end -}}
+{{- define "otterize.mapper.configMapName" -}}
+otterize-network-mapper-store
+{{- end -}}
 {{ define "otterize.mapper.port" -}}
 9090
 {{- end -}}

--- a/network-mapper/templates/mapper-configmap.yaml
+++ b/network-mapper/templates/mapper-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "otterize.mapper.configMapName" . }}
+data: {}
+binaryData: {} # mapper will add data here on runtime

--- a/network-mapper/templates/mapper-role.yaml
+++ b/network-mapper/templates/mapper-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "otterize.mapper.fullName" . }}
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - 'configmaps'
+    resourceNames:
+      - {{ template "otterize.mapper.configMapName" . }}
+    verbs:
+      - 'get'
+      - 'update'

--- a/network-mapper/templates/mapper-serviceaccount.yaml
+++ b/network-mapper/templates/mapper-serviceaccount.yaml
@@ -15,3 +15,16 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "otterize.mapper.fullName" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "otterize.mapper.fullName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "otterize.mapper.fullName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "otterize.mapper.fullName" . }}
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This PR supports the same change in the network mapper repo, see there for the full details:
https://github.com/otterize/network-mapper/pull/40