### PR TITLE
Added the enableEnforcement flag to disable of all types of enforcement in one place

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -23,6 +23,9 @@ spec:
     spec:
       containers:
       - args:
+        {{- if eq false .Values.operator.enableEnforcement }}
+          - --enable-enforcement=false
+        {{- end }}
         {{- if eq false .Values.operator.enableNetworkPolicyCreation }}
         - --enable-network-policy-creation=false
         {{- end }}

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -4,6 +4,11 @@ operator:
   tag: latest
   pullPolicy:
 
+  # `enableEnforcement` controls all the enforcement that the intents-operator performs. When set to false, enforcement
+  # is disabled globally (both for network policies and Kafka ACL). When set to true, you may use the other flags for
+  # more granular enforcement settings (e.g. disable only kafka ACL)
+  enableEnforcement: true
+
   autoGenerateTLSUsingSpireIntegration: false
   enableNetworkPolicyCreation: true
   enableKafkaACLCreation: true

--- a/otterize-kubernetes/values.yaml
+++ b/otterize-kubernetes/values.yaml
@@ -17,6 +17,7 @@ global:
 # alias for intents-operator values
 intentsOperator:
   operator:
+    enableEnforcement: true
     autoGenerateTLSUsingSpireIntegration: true
     enableNetworkPolicyCreation: true
     enableKafkaACLCreation: true


### PR DESCRIPTION
This PR adds the enableEnforcement helm value to the operator, which can be used in order to disable all the enforcement abilities of the intents operator at once.

Goes together with the intents-operator PR: https://github.com/otterize/intents-operator/pull/101