### PR TITLE
Aligned cloud values in intents-operator and network-mapper

### DIFF
--- a/intents-operator/README.md
+++ b/intents-operator/README.md
@@ -5,22 +5,18 @@
 |----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `global.allowGetAllResources`    | If defined overrides `allowGetAllResources`.                                                                                                |         |
 
-
 ## Operator parameters
-
-| Key                                             | Description                                                                                                        | Default            |
-|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|--------------------|
-| `operator.image.repository`                     | Intents Operator image repository.                                                                                 | `otterize`         |
-| `operator.image.image`                          | Intents Operator image.                                                                                            | `intents-operator` |
-| `operator.image.tag`                            | Intents Operator image tag.                                                                                        | `latest`           |
-| `operator.pullPolicy`                           | Intents Operator image pull policy.                                                                                | `(none)`           |
-| `operator.autoGenerateTLSUsingSpireIntegration` | If true, adds the necessary pod annotations in order to integrate with spire-integration, and get tls certificate. | `true`            |
-| `operator.autoCreateNetworkPoliciesForExternalTraffic` | Automatically allow external traffic, if a new ClientIntents resource would result in blocking external (internet) traffic and there is an Ingress/Service resource indicating external traffic is expected. | `true`           |
-| `operator.resources`                            | Resources override.                                                                                                |                    |
-
+| Key                                                    | Description                                                                                                                                                                                                  | Default            |
+|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| `operator.image.repository`                            | Intents Operator image repository.                                                                                                                                                                           | `otterize`         |
+| `operator.image.image`                                 | Intents Operator image.                                                                                                                                                                                      | `intents-operator` |
+| `operator.image.tag`                                   | Intents Operator image tag.                                                                                                                                                                                  | `latest`           |
+| `operator.pullPolicy`                                  | Intents Operator image pull policy.                                                                                                                                                                          | `(none)`           |
+| `operator.autoGenerateTLSUsingSpireIntegration`        | If true, adds the necessary pod annotations in order to integrate with spire-integration, and get tls certificate.                                                                                           | `true`             |
+| `operator.autoCreateNetworkPoliciesForExternalTraffic` | Automatically allow external traffic, if a new ClientIntents resource would result in blocking external (internet) traffic and there is an Ingress/Service resource indicating external traffic is expected. | `true`             |
+| `operator.resources`                                   | Resources override.                                                                                                                                                                                          |                    |
 
 ## Watcher parameters
-
 | Key                        | Description                | Default                        |
 |----------------------------|----------------------------|--------------------------------|
 | `watcher.image.repository` | Watcher image repository.  | `otterize`                     |
@@ -29,8 +25,14 @@
 | `watcher.pullPolicy`       | Watcher image pull policy. | `(none)`                       |
 | `watcher.resources`        | Watcher Resources.         |                                |
 
-## Common parameters
+## Cloud parameters
+| Key                              | Description                                     | Default  |
+|----------------------------------|-------------------------------------------------|----------|
+| `cloud.credentials.clientId`     | Client ID for connecting to Otterize Cloud.     | `(none)` |
+| `cloud.credentials.clientSecret` | Client secret for connecting to Otterize Cloud. | `(none)` |
+| `cloud.apiAddress`               | Overrides Otterize Cloud default API address.   | `(none)` |
 
+## Common parameters
 | Key                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `allowGetAllResources` | Gives get, list and watch permission to watch on all resources. This is used to resolve service names when pods have owners that are custom resources. When disabled, a limited set of permissions is used that only allows access to built-in Kubernetes resources that deploy Pods and Pods themselves - Deployments, StatefulSets, DaemonSets, ReplicaSets and Services. Resolving may not be able to complete if the owning resource is not one of those. | `true`  |

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -79,17 +79,17 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          {{ if .Values.operator.cloud.apiAddress }}
+          {{ if .Values.cloud.apiAddress }}
           - name: OTTERIZE_API_ADDRESS
-            value: "{{ .Values.operator.cloud.apiAddress }}"
+            value: "{{ .Values.cloud.apiAddress }}"
           {{ end }}
-          {{ if .Values.operator.cloud.credentials.clientId }}
+          {{ if .Values.cloud.credentials.clientId }}
           - name: OTTERIZE_CLIENT_ID
-            value: "{{ .Values.operator.cloud.credentials.clientId }}"
+            value: "{{ .Values.cloud.credentials.clientId }}"
           {{ end }}
-          {{ if .Values.operator.cloud.credentials.clientSecret }}
+          {{ if .Values.cloud.credentials.clientSecret }}
           - name: OTTERIZE_CLIENT_SECRET
-            value: "{{ .Values.operator.cloud.credentials.clientSecret }}"
+            value: "{{ .Values.cloud.credentials.clientSecret }}"
           {{ end }}
         volumeMounts:
         - mountPath: /controller_manager_config.yaml

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -4,12 +4,6 @@ operator:
   tag: latest
   pullPolicy:
 
-  cloud:
-    # fill credentials in order to connect to Otterize Cloud
-    credentials:
-      clientId:
-      clientSecret:
-
   # `enableEnforcement` controls all the enforcement that the intents-operator performs. When set to false, enforcement
   # is disabled globally (both for network policies and Kafka ACL). When set to true, you may use the other flags for
   # more granular enforcement settings (e.g. disable only kafka ACL)
@@ -48,6 +42,12 @@ watcher:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+cloud:
+  credentials:
+    # fill clientId and clientSecret in order to connect to Otterize Cloud
+    clientId:
+    clientSecret:
 
 # allowGetAllResources gives get permission to watch on all resources. If disabled, the operator will only
 # be able to resolve pods up to their built-in owners. For example, a Pod is owned by a ReplicaSet that is owned by a Deployment.

--- a/network-mapper/README.md
+++ b/network-mapper/README.md
@@ -10,7 +10,6 @@
 | `mapper.resources`             | Resources override.                  | `(none)`                       |
 | `mapper.uploadIntervalSeconds` | Interval for uploading data to cloud | `60`                           |
 
-
 ## Sniffer parameters
 | Key                        | Description               | Default                  |
 |----------------------------|---------------------------|--------------------------|
@@ -20,6 +19,12 @@
 | `sniffer.pullPolicy`       | Sniffer pull policy.      | `(none)`                 |
 | `sniffer.resources`        | Resources override.       | `(none)`                 |   
 
+## Cloud parameters
+| Key                              | Description                                     | Default  |
+|----------------------------------|-------------------------------------------------|----------|
+| `cloud.credentials.clientId`     | Client ID for connecting to Otterize Cloud.     | `(none)` |
+| `cloud.credentials.clientSecret` | Client secret for connecting to Otterize Cloud. | `(none)` |
+| `cloud.apiAddress`               | Overrides Otterize Cloud default API address.   | `(none)` |
 
 ## Global parameters
 | Key                              | Description                                                                                                                                 | Default |
@@ -27,11 +32,7 @@
 | `global.allowGetAllResources`    | If defined overrides `allowGetAllResources`.                                                                                                |         |
 
 ## Common parameters
-
 | Key                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Default                        |
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|
 | `debug`                | Enable debug logs                                                                                                                                                                                                                                                                                                                                                                                                                                             | `false`                        |
 | `allowGetAllResources` | Gives get, list and watch permission to watch on all resources. This is used to resolve service names when pods have owners that are custom resources. When disabled, a limited set of permissions is used that only allows access to built-in Kubernetes resources that deploy Pods and Pods themselves - Deployments, StatefulSets, DaemonSets, ReplicaSets and Services. Resolving may not be able to complete if the owning resource is not one of those. | `true`                         |
-| `APIAddress`           | Address of Otterize Cloud API.                                                                                                                                                                                                                                                                                                                                                                                                                                | `https://app.otterize.com/api` |
-| `clientSecret`         | Client secret for connecting to Otterize Cloud.                                                                                                                                                                                                                                                                                                                                                                                                               | `(none)`                       |
-| `clientId`             | Client ID for connecting to Otterize Cloud.                                                                                                                                                                                                                                                                                                                                                                                                                   | `(none)`                       |

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -25,12 +25,18 @@ spec:
           env:
             - name: OTTERIZE_DEBUG
               value: {{ .Values.debug | quote }}
+            {{ if .Values.cloud.apiAddress }}
             - name: OTTERIZE_API_ADDRESS
-              value: {{ .Values.APIAddress | default "https://app.otterize.com/api" | quote }}
+              value: "{{ .Values.cloud.apiAddress }}"
+            {{ end }}
+            {{ if .Values.cloud.credentials.clientId }}
             - name: OTTERIZE_CLIENT_ID
-              value: {{ .Values.clientId | quote }}
+              value: "{{ .Values.cloud.credentials.clientId }}"
+            {{ end }}
+            {{ if .Values.cloud.credentials.clientSecret }}
             - name: OTTERIZE_CLIENT_SECRET
-              value: {{ .Values.clientSecret | quote }}
+              value: "{{ .Values.cloud.credentials.clientSecret }}"
+            {{ end }}
             - name: OTTERIZE_UPLOAD_INTERVAL_SECONDS
               value: {{ .Values.mapper.uploadIntervalSeconds | default "60" | quote }}
           securityContext:

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -35,6 +35,12 @@ sniffer:
   #   cpu: 100m
   #   memory: 128Mi
 
+cloud:
+  credentials:
+    # fill clientId and clientSecret in order to connect to Otterize Cloud
+    clientId:
+    clientSecret:
+
 debug: false
 allowGetAllResources: true
 

--- a/otterize-kubernetes/README.md
+++ b/otterize-kubernetes/README.md
@@ -24,10 +24,12 @@ These parameters are used by multiple charts, and must be kept the same for the 
 All configurable parameters of intents-operator can be configured under the alias `intentsOperator`.
 Further information about intents-operator parameters can be found [in the Intents Operator's helm chart](https://github.com/otterize/helm-charts/tree/main/intents-operator).
 
-| Key                                                  | Description                                                    | Default          |
-|------------------------------------------------------|----------------------------------------------------------------|------------------|
-| `intentsOperator.autoGenerateTLSUsingSpireIntegration` | Use spire-integration to create TLS cert for intents-operator. | `true`           |
-| `intentsOperator.operator.autoCreateNetworkPoliciesForExternalTraffic` | Automatically allow external traffic, if a new ClientIntents resource would result in blocking external (internet) traffic and there is an Ingress/Service resource indicating external traffic is expected. | `true`           |
+| Key                                                                    | Description                                                                                                                                                                                                  | Default  |
+|------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `intentsOperator.autoGenerateTLSUsingSpireIntegration`                 | Use spire-integration to create TLS cert for intents-operator.                                                                                                                                               | `true`   |
+| `intentsOperator.operator.autoCreateNetworkPoliciesForExternalTraffic` | Automatically allow external traffic, if a new ClientIntents resource would result in blocking external (internet) traffic and there is an Ingress/Service resource indicating external traffic is expected. | `true`   |
+| `intentsOperator.cloud.credentials.clientId`                           | Client ID for connecting to Otterize Cloud.                                                                                                                                                                  | `(none)` |
+| `intentsOperator.cloud.credentials.clientSecret`                       | Client secret for connecting to Otterize Cloud.                                                                                                                                                              | `(none)` |
 
 ## SPIRE parameters
 All configurable parameters of SPIRE can be configured under the alias `spire`.

--- a/otterize-kubernetes/values.yaml
+++ b/otterize-kubernetes/values.yaml
@@ -24,6 +24,11 @@ intentsOperator:
     autoCreateNetworkPoliciesForExternalTraffic: true
   watchedNamespaces: null # by default, watch all
   watcher: {}
+  cloud:
+    credentials:
+      # fill clientId and clientSecret in order to connect to Otterize Cloud
+      clientId:
+      clientSecret:
 
 # alias for spire values
 spire: {}


### PR DESCRIPTION
Exposes the cloud connectivity parameters in the same manner for both intents-operator and network-mapper
Also updated in docs, and added to otterize-Kubernetes helm chart