### PR TITLE
Use mirrored SPIRE images

### DIFF
--- a/spire/README.md
+++ b/spire/README.md
@@ -37,7 +37,7 @@ ___
 | Key                             | Description                       | Default                          |
 |---------------------------------|-----------------------------------|----------------------------------|
 | `agent.image.pullPolicy`        | Agent image pull policy           | `"IfNotPresent"`                 |
-| `agent.image.repository`        | Agent image repository            | `"gcr.io/spiffe-io/spire-agent"` |
+| `agent.image.repository`        | Agent image repository            | `"otterize/spire-agent"` |
 | `agent.image.tag`               | Agent image tag                   | `""`                             |
 | `agent.logLevel `               | Agent log level                   | `"INFO"`                         |
 | `agent.skipKubeletVerification` | Set to `True` if you use Minikube | `false`                          |
@@ -52,7 +52,7 @@ ___
 | `server.dataStorage.size`         | data storage - size          | `"1Gi"`                            |
 | `server.dataStorage.storageClass` | data storage - storage class | `nil`                              |
 | `server.image.pullPolicy`         | image pull policy            | `"IfNotPresent"`                   |
-| `server.image.repository`         | image repository             | `"gcr.io/spiffe-io/spire-server"`  |
+| `server.image.repository`         | image repository             | `"otterize/spire-server"`  |
 | `server.image.tag`                | image tag                    | `""`                               |
 | `server.logLevel`                 | log level                    | `"INFO"`                           |
 | `server.rootCATTL`                | determine root_ca TTL        | `"26280h"`                         |

--- a/spire/templates/agent-daemonset.yaml
+++ b/spire/templates/agent-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
           # This is a small image with wait-for-it, choose whatever image
           # you prefer that waits for a service to be up. This image is built
           # from https://github.com/lqhl/wait-for-it
-          image: gcr.io/spiffe-io/wait-for-it:latest
+          image: otterize/wait-for-it:latest
           {{- if .Values.global.spire.serverServiceName}}
           args: ["-t", "30", "{{ .Values.global.spire.serverServiceName }}:8081"]
           {{- else}}

--- a/spire/values.yaml
+++ b/spire/values.yaml
@@ -11,7 +11,7 @@ server:
 
   logLevel: DEBUG
   image:
-    repository: gcr.io/spiffe-io/spire-server
+    repository: otterize/spire-server
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
@@ -43,7 +43,7 @@ agent:
   skipKubeletVerification: true
   logLevel: DEBUG
   image:
-    repository: gcr.io/spiffe-io/spire-agent
+    repository: otterize/spire-agent
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""


### PR DESCRIPTION
This PR uses Otterize's mirror of SPIRE images for cases where a corporate firewall blocks access to gcr.io.