### PR TITLE
Fix SPIRE issue when running on latest minikube version

### DIFF
--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -28,7 +28,7 @@ description: |
   ```
 type: application
 version: 1.0.0
-appVersion: "1.0.2"
+appVersion: "1.5.4"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent"]
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"

--- a/spire/templates/scripts-configmap.yaml
+++ b/spire/templates/scripts-configmap.yaml
@@ -6,9 +6,15 @@ metadata:
 data:
   init_entries.sh: |-
     set -e
+    echo "waiting for spire process to start"
+    while ! pgrep spire-server > /dev/null; do sleep 1; done
+    SPIRE_SERVER_ROOT_PATH="/proc/$(pgrep spire-server)/root"
+    alias spire_server="${SPIRE_SERVER_ROOT_PATH}/opt/spire/bin/spire-server"
+    SOCKET_FLAG="-socketPath ${SPIRE_SERVER_ROOT_PATH}/tmp/spire-server/private/api.sock"
+
     echo "checking spire-server status"
-    while ! /opt/spire/bin/spire-server entry show &> /dev/null; do
-      echo "server seems to be down"
+    while ! spire_server entry show ${SOCKET_FLAG} &> /dev/null; do
+      echo "waiting for spire-server to start..."
       sleep 2
     done
     echo "server is up!"
@@ -20,12 +26,15 @@ data:
     AGENT_SELECTORS="-selector k8s_psat:agent_ns:{{ .Release.Namespace }} -selector k8s_psat:agent_sa:{{ include "spire.serviceAccountName" . }}-agent"
 
     echo "ensuring agent entry"
-    if /opt/spire/bin/spire-server entry show -spiffeID $AGENT_SPIFFE_ID $AGENT_SELECTORS | grep -q "Found 0 entries" &> /dev/null; then
-      /opt/spire/bin/spire-server entry create -spiffeID $AGENT_SPIFFE_ID $AGENT_SELECTORS -node
+    if spire_server entry show ${SOCKET_FLAG} -spiffeID $AGENT_SPIFFE_ID $AGENT_SELECTORS | grep -q "Found 0 entries" &> /dev/null; then
+      spire_server entry create ${SOCKET_FLAG} -spiffeID $AGENT_SPIFFE_ID $AGENT_SELECTORS -node
     fi
 
     SPIRE_INTEGRATION_SELECTORS="-selector k8s:ns:{{ .Release.Namespace }} -selector k8s:pod-label:app:credentials-operator"
     echo "ensuring integration entry"
-    if /opt/spire/bin/spire-server entry show -spiffeID $INTEGRATION_SPIFFE_ID -parentID $AGENT_SPIFFE_ID $SPIRE_INTEGRATION_SELECTORS | grep -q "Found 0 entries" &> /dev/null; then
-      /opt/spire/bin/spire-server entry create -spiffeID $INTEGRATION_SPIFFE_ID -parentID $AGENT_SPIFFE_ID $SPIRE_INTEGRATION_SELECTORS -admin
+    if spire_server entry show ${SOCKET_FLAG} -spiffeID $INTEGRATION_SPIFFE_ID -parentID $AGENT_SPIFFE_ID $SPIRE_INTEGRATION_SELECTORS | grep -q "Found 0 entries" &> /dev/null; then
+      spire_server entry create ${SOCKET_FLAG} -spiffeID $INTEGRATION_SPIFFE_ID -parentID $AGENT_SPIFFE_ID $SPIRE_INTEGRATION_SELECTORS -admin
     fi
+
+    echo "spire initialized successfully!"
+    while pgrep spire-server > /dev/null; do sleep 1; done

--- a/spire/templates/server-statefulset.yaml
+++ b/spire/templates/server-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}-server-init-sidecar
+        - name: initial-entry-registration-sidecar
           image: busybox
           command: ["/bin/sh", "/run/scripts/init_entries.sh" ]
           volumeMounts:

--- a/spire/templates/server-statefulset.yaml
+++ b/spire/templates/server-statefulset.yaml
@@ -33,6 +33,12 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        - name: {{ .Chart.Name }}-server-init-sidecar
+          image: busybox
+          command: ["/bin/sh", "/run/scripts/init_entries.sh" ]
+          volumeMounts:
+            - name: spire-scripts
+              mountPath: /run/scripts
         - name: {{ .Chart.Name }}-server
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -41,10 +47,6 @@ spec:
           args:
             - -config
             - /run/spire/config/server.conf
-          lifecycle:
-            postStart:
-              exec:
-                command: ["/bin/sh", "/run/scripts/init_entries.sh" ]
           ports:
             - name: grpc
               containerPort: 8081
@@ -56,8 +58,6 @@ spec:
             - name: spire-config
               mountPath: /run/spire/config
               readOnly: true
-            - name: spire-scripts
-              mountPath: /run/scripts
             {{- if eq (.Values.server.dataStorage.enabled | toString) "true" }}
             - name: spire-data
               mountPath: /run/spire/data


### PR DESCRIPTION
SPIRE 1.0.2 has an issue on minikube 1.29.0 that makes the spire-agent fail to create the required entities using the k8s selector, and causes the credentials-operator to crash-loop as it fails to access SPIRE.

This PR upgrades the spire image to the latest version (1.5.4), which supports the minikube 1.29.0.
Because the new image doesn't have a shell, we used a sidecar to run the init commands instead of `postStart`.