### PR TITLE
Add helm 'keep' annotation to not remove CRDs in helm uninstall.

### DIFF
--- a/intents-operator/Chart.yaml
+++ b/intents-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: intents-operator
 description: Otterize intents operator
 type: application
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/otterize/intents-operator
 sources:
   - https://github.com/otterize/intents-operator

--- a/intents-operator/templates/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/templates/clientintents-customresourcedefinition.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    "helm.sh/resource-policy": keep
   creationTimestamp: null
   name: clientintents.k8s.otterize.com
 spec:

--- a/intents-operator/templates/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/templates/kafkaserverconfigs-customresourcedefinition.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    "helm.sh/resource-policy": keep
   creationTimestamp: null
   name: kafkaserverconfigs.k8s.otterize.com
 spec:


### PR DESCRIPTION
### Description
This is the first step for moving CRDs out of `templates` dir to their own dedicated directory, `crds`, as [helm best practices suggest](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/).
Addresses part one of this [issue](https://github.com/otterize/intents-operator/issues/134).
