### PR TITLE
Support custom root CAs when initializing cloud client - provide root CA secret reference via helm charts

### DIFF
--- a/credentials-operator/templates/_helpers.tpl
+++ b/credentials-operator/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "otterize.operator.apiExtraCAPath" -}}
+/etc/otterize-api-extra-ca-pem
+{{- end -}}
+
+{{- define "otterize.operator.apiExtraCAPEM" -}}
+{{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
+{{- end -}}

--- a/credentials-operator/templates/deployment.yaml
+++ b/credentials-operator/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
           - name: OTTERIZE_CLIENT_SECRET
             value: "{{ .Values.global.otterizeCloud.credentials.clientSecret }}"
           {{ end }}
+          {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+          - name: OTTERIZE_API_EXTRA_CA_PEM
+            value: {{ template "otterize.operator.apiExtraCAPEM" }}
+          {{ end }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -92,19 +96,29 @@ spec:
           capabilities:
             drop:
              - "ALL"
-{{- if eq "false" (.Values.global.otterizeCloud.useCloudToGenerateTLSCredentials | toString) }}
         volumeMounts:
+{{- if eq "false" (.Values.global.otterizeCloud.useCloudToGenerateTLSCredentials | toString) }}
         - mountPath: {{ .Values.spire.socketsPath }}
           name: spire-agent-socket
           readOnly: true
 {{- end }}
+        {{- if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+        - mountPath: {{ template "otterize.operator.apiExtraCAPath" }}
+          name: api-extra-ca-pem
+          readOnly: true
+        {{- end }}
       securityContext:
         runAsNonRoot: true
       terminationGracePeriodSeconds: 10
-{{- if eq "false" (.Values.global.otterizeCloud.useCloudToGenerateTLSCredentials | toString) }}
       volumes:
+{{- if eq "false" (.Values.global.otterizeCloud.useCloudToGenerateTLSCredentials | toString) }}
       - hostPath:
           path: {{ .Values.spire.socketsPath }}
           type: Directory
         name: spire-agent-socket
 {{- end }}
+      {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+      - name: api-extra-ca-pem
+        secret:
+          secretName: {{ .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+      {{ end }}

--- a/credentials-operator/values.yaml
+++ b/credentials-operator/values.yaml
@@ -24,10 +24,11 @@ global:
   otterizeCloud:
     useCloudToGenerateTLSCredentials: false
     credentials:
-      useCredentials: false
       # fill clientId and clientSecret in order to connect to Otterize Cloud
       clientId:
       clientSecret:
+    # (optional) fill with the name of a secret containing extra root CA PEM file used to connect to Otterize Cloud
+    apiExtraCAPEMSecret:
   spire:
     serverServiceName:
   # If defined overrides `allowGetAllResources`

--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -13,3 +13,11 @@
 {{- define "otterize.operator.ca" -}}
 {{ template "otterize.operator.tlsPath" }}/bundle.pem
 {{- end -}}
+
+{{- define "otterize.operator.apiExtraCAPath" -}}
+/etc/otterize-api-extra-ca-pem
+{{- end -}}
+
+{{- define "otterize.operator.apiExtraCAPEM" -}}
+{{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
+{{- end -}}

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -91,6 +91,10 @@ spec:
           - name: OTTERIZE_CLIENT_SECRET
             value: "{{ .Values.global.otterizeCloud.credentials.clientSecret }}"
           {{ end }}
+          {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+          - name: OTTERIZE_API_EXTRA_CA_PEM
+            value: {{ template "otterize.operator.apiExtraCAPEM" }}
+          {{ end }}
         volumeMounts:
         - mountPath: /controller_manager_config.yaml
           name: manager-config
@@ -100,6 +104,11 @@ spec:
         {{- if .Values.operator.autoGenerateTLSUsingCredentialsOperator }}
         - mountPath: {{ template "otterize.operator.tlsPath" }}
           name: spire-tls
+          readOnly: true
+        {{- end }}
+        {{- if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+        - mountPath: {{ template "otterize.operator.apiExtraCAPath" }}
+          name: api-extra-ca-pem
           readOnly: true
         {{- end }}
       - args:
@@ -137,5 +146,10 @@ spec:
       - name: spire-tls
         secret:
           secretName: intents-operator-spire-tls-controller-manager
+      {{ end }}
+      {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+      - name: api-extra-ca-pem
+        secret:
+          secretName: {{ .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
       {{ end }}
       - name: cert

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -58,3 +58,5 @@ global:
       # fill clientId and clientSecret in order to connect to Otterize Cloud
       clientId:
       clientSecret:
+    # (optional) fill with the name of a secret containing extra root CA PEM file used to connect to Otterize Cloud
+    apiExtraCAPEMSecret:

--- a/network-mapper/templates/_helpers.tpl
+++ b/network-mapper/templates/_helpers.tpl
@@ -10,3 +10,11 @@ otterize-network-mapper-store
 {{ define "otterize.mapper.port" -}}
 9090
 {{- end -}}
+
+{{- define "otterize.operator.apiExtraCAPath" -}}
+/etc/otterize-api-extra-ca-pem
+{{- end -}}
+
+{{- define "otterize.operator.apiExtraCAPEM" -}}
+{{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
+{{- end -}}

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -37,11 +37,27 @@ spec:
             - name: OTTERIZE_CLIENT_SECRET
               value: "{{ .Values.global.otterizeCloud.credentials.clientSecret }}"
             {{ end }}
+            {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+            - name: OTTERIZE_API_EXTRA_CA_PEM
+              value: {{ template "otterize.operator.apiExtraCAPEM" }}
+            {{ end }}
             - name: OTTERIZE_UPLOAD_INTERVAL_SECONDS
               value: {{ .Values.mapper.uploadIntervalSeconds | default "60" | quote }}
+          volumeMounts:
+            {{- if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+            - mountPath: {{ template "otterize.operator.apiExtraCAPath" }}
+              name: api-extra-ca-pem
+              readOnly: true
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - "ALL"
       serviceAccountName: {{ template "otterize.mapper.fullName" . }}
+      volumes:
+        {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+        - name: api-extra-ca-pem
+          secret:
+            secretName: {{ .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
+        {{ end }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -47,3 +47,6 @@ global:
       # fill clientId and clientSecret in order to connect to Otterize Cloud
       clientId:
       clientSecret:
+
+    # (optional) fill with the name of a secret containing extra root CA PEM file used to connect to Otterize Cloud
+    apiExtraCAPEMSecret:

--- a/otterize-kubernetes/values.yaml
+++ b/otterize-kubernetes/values.yaml
@@ -8,7 +8,6 @@ global:
   otterizeCloud:
     useCloudToGenerateTLSCredentials: false
     credentials:
-      useCredentials: false
       # fill clientId and clientSecret in order to connect to Otterize Cloud
       clientId:
       clientSecret:


### PR DESCRIPTION
### Description
Support custom root CAs when initializing cloud client - provide root CA secret reference via helm charts

### References

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
