### PR TITLE
Bugfix: Use Secret to store Otterize Cloud client secret

### DIFF
--- a/credentials-operator/templates/credentials-operator-client-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-client-secret.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.global.otterizeCloud.credentials.clientSecret }}
+apiVersion: v1
+type: Opaque
+kind: Secret
+metadata:
+  name: credentials-operator-otterize-cloud-client-secret
+data:
+  otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
+{{ end }}

--- a/credentials-operator/templates/deployment.yaml
+++ b/credentials-operator/templates/deployment.yaml
@@ -70,7 +70,10 @@ spec:
           {{ end }}
           {{ if .Values.global.otterizeCloud.credentials.clientSecret }}
           - name: OTTERIZE_CLIENT_SECRET
-            value: "{{ .Values.global.otterizeCloud.credentials.clientSecret }}"
+            valueFrom:
+              secretKeyRef:
+                name: credentials-operator-otterize-cloud-client-secret
+                key: otterize-cloud-client-secret
           {{ end }}
           {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
           - name: OTTERIZE_API_EXTRA_CA_PEM

--- a/intents-operator/templates/intents-operator-client-secret.yaml
+++ b/intents-operator/templates/intents-operator-client-secret.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.global.otterizeCloud.credentials.clientSecret }}
+apiVersion: v1
+type: Opaque
+kind: Secret
+metadata:
+  name: intents-operator-otterize-cloud-client-secret
+data:
+  otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
+{{ end }}

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -89,7 +89,10 @@ spec:
           {{ end }}
           {{ if .Values.global.otterizeCloud.credentials.clientSecret }}
           - name: OTTERIZE_CLIENT_SECRET
-            value: "{{ .Values.global.otterizeCloud.credentials.clientSecret }}"
+            valueFrom:
+              secretKeyRef:
+                name: intents-operator-otterize-cloud-client-secret
+                key: otterize-cloud-client-secret
           {{ end }}
           {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
           - name: OTTERIZE_API_EXTRA_CA_PEM

--- a/network-mapper/templates/mapper-client-secret.yaml
+++ b/network-mapper/templates/mapper-client-secret.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.global.otterizeCloud.credentials.clientSecret }}
+apiVersion: v1
+type: Opaque
+kind: Secret
+metadata:
+  name: mapper-otterize-cloud-client-secret
+data:
+  otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
+{{ end }}

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -35,7 +35,10 @@ spec:
             {{ end }}
             {{ if .Values.global.otterizeCloud.credentials.clientSecret }}
             - name: OTTERIZE_CLIENT_SECRET
-              value: "{{ .Values.global.otterizeCloud.credentials.clientSecret }}"
+              valueFrom:
+                secretKeyRef:
+                  name: mapper-otterize-cloud-client-secret
+                  key: otterize-cloud-client-secret
             {{ end }}
             {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
             - name: OTTERIZE_API_EXTRA_CA_PEM

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -20,7 +20,7 @@ dependencies:
     repository: file://./../spire
   - name: intents-operator
     alias: intentsOperator
-    version: ">= 0.1.1"
+    version: ">= 0.1.2"
     condition: deployment.intentsOperator
     repository: file://./../intents-operator
   - name: network-mapper


### PR DESCRIPTION
Prior to this PR, when passed by values, the client secret would be passed as an environment variable rather than a Secret.