### PR TITLE
Add internal aliases for networkMapper components in otterize-k8s helm chart

### DIFF
--- a/otterize-kubernetes/values.yaml
+++ b/otterize-kubernetes/values.yaml
@@ -42,4 +42,7 @@ spire: {}
 credentialsOperator: {}
 
 # alias for network-mapper values
-networkMapper: {}
+networkMapper:
+  mapper: {}
+  sniffer: {}
+  kafkawatcher: {} # experimental


### PR DESCRIPTION
### Description
Add internal aliases for networkMapper components in otterize-k8s helm chart, in order to allow configuration them via flags passed on helm install, like so:
```
helm upgrade -i otterize -n otterize-system --create-namespace ./  --set networkMapper.kafkawatcher.enable=true --set networkMapper.kafkawatcher.kafkaServers="kafka-0.kafka"
```