### PR TITLE
Update cluster roles for Istio

### DIFF
--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -123,3 +123,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - security.istio.io
+  resources:
+  - authorizationpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/intents-operator/templates/watcher-clusterrole.yaml
+++ b/intents-operator/templates/watcher-clusterrole.yaml
@@ -16,6 +16,29 @@ rules:
       - watch
       - patch
   - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.istio.io
+    resources:
+      - authorizationpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - "apps"
     resources:
       - 'daemonsets'


### PR DESCRIPTION
Updates intents operator cluster role to manage Istio authorization policies resources. 
Since the pod watcher can also create the policies it gets the ability to trigger events on success or failure. 