### PR TITLE
Use chart.AppVersion as default image tag instead of using latest

### DIFF
--- a/credentials-operator/Chart.yaml
+++ b/credentials-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: credentials-operator
 description: credentials-operator
 type: application
 version: 0.1.0
-appVersion: "1.0.0"
+appVersion: v0.1.4
 home: https://github.com/otterize/credentials-operator
 sources:
   - https://github.com/otterize/credentials-operator

--- a/credentials-operator/templates/deployment.yaml
+++ b/credentials-operator/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ .Values.operator.tag }}"
+        image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ default $.Chart.AppVersion .Values.operator.tag }}"
         {{ if .Values.operator.pullPolicy }}
         imagePullPolicy: {{ .Values.operator.pullPolicy }}
         {{ end }}

--- a/credentials-operator/values.yaml
+++ b/credentials-operator/values.yaml
@@ -1,7 +1,6 @@
 operator:
   repository: otterize
   image: credentials-operator
-  tag: latest
   pullPolicy:
 
 resources: { }

--- a/intents-operator/Chart.yaml
+++ b/intents-operator/Chart.yaml
@@ -3,6 +3,7 @@ name: intents-operator
 description: Otterize intents operator
 type: application
 version: 0.1.2
+appVersion: v0.1.19
 home: https://github.com/otterize/intents-operator
 sources:
   - https://github.com/otterize/intents-operator

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         {{ end }}
         command:
         - /manager
-        image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ .Values.operator.tag }}"
+        image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ default $.Chart.AppVersion .Values.operator.tag }}"
         {{ if .Values.operator.pullPolicy }}
         imagePullPolicy: {{ .Values.operator.pullPolicy }}
         {{ end }}

--- a/intents-operator/templates/watcher-deployment.yaml
+++ b/intents-operator/templates/watcher-deployment.yaml
@@ -21,7 +21,7 @@ spec:
             {{- range .Values.watchedNamespaces }}
             - --watched-namespaces={{ . | quote }}
             {{- end }}
-          image: "{{ .Values.watcher.repository }}/{{ .Values.watcher.image }}:{{ .Values.watcher.tag }}"
+          image: "{{ .Values.watcher.repository }}/{{ .Values.watcher.image }}:{{ default $.Chart.AppVersion .Values.watcher.tag }}"
           {{ if .Values.watcher.pullPolicy }}
           imagePullPolicy: {{ .Values.watcher.pullPolicy }}
           {{ end }}

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -1,7 +1,6 @@
 operator:
   repository: otterize
   image: intents-operator
-  tag: latest
   pullPolicy:
 
   autoGenerateTLSUsingCredentialsOperator: false
@@ -29,7 +28,6 @@ operator:
 watcher:
   repository: otterize
   image: intents-operator-pod-watcher
-  tag: latest
   pullPolicy:
 
   resources: {}

--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-mapper
 type: application
 version: 0.1.0
-appVersion: 0.0.1
+appVersion: v0.1.15
 home: https://github.com/otterize/network-mapper
 sources:
   - https://github.com/otterize/network-mapper

--- a/network-mapper/templates/exp/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/exp/kafka-watcher-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{ end }}
       containers:
         - name: {{ template "otterize.kafkawatcher.fullName" . }}
-          image: "{{ .Values.kafkawatcher.repository }}/{{ .Values.kafkawatcher.image }}:{{ .Values.kafkawatcher.tag }}"
+          image: "{{ .Values.kafkawatcher.repository }}/{{ .Values.kafkawatcher.image }}:{{  .Values.kafkawatcher.tag }}"
           {{ if .Values.kafkawatcher.pullPolicy }}
           imagePullPolicy: {{ .Values.kafkawatcher.pullPolicy }}
           {{ end }}

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       {{ end }}
       containers:
         - name: {{ template "otterize.mapper.fullName" . }}
-          image: "{{ .Values.mapper.repository }}/{{ .Values.mapper.image }}:{{ .Values.mapper.tag }}"
+          image: "{{ .Values.mapper.repository }}/{{ .Values.mapper.image }}:{{ default $.Chart.AppVersion .Values.mapper.tag }}"
           {{ if .Values.mapper.pullPolicy }}
           imagePullPolicy: {{ .Values.mapper.pullPolicy }}
           {{ end }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
       {{ end }}
       containers:
       - name: {{ template "otterize.sniffer.fullName" . }}
-        image: "{{ .Values.sniffer.repository }}/{{ .Values.sniffer.image }}:{{ .Values.sniffer.tag }}"
+        image: "{{ .Values.sniffer.repository }}/{{ .Values.sniffer.image }}:{{ default $.Chart.AppVersion .Values.sniffer.tag }}"
         {{ if .Values.sniffer.pullPolicy }}
         imagePullPolicy: {{ .Values.sniffer.pullPolicy }}
         {{ end }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -2,7 +2,6 @@
 mapper:
   repository: otterize
   image: network-mapper
-  tag: latest
   pullPolicy:
   pullSecrets:
   resources: { }
@@ -22,7 +21,6 @@ sniffer:
   enable: true # enable/disable entire installation of the network sniffer
   repository: otterize
   image: network-mapper-sniffer
-  tag: latest
   pullPolicy:
   pullSecrets:
   resources: { }
@@ -42,7 +40,6 @@ kafkawatcher:
   enable: false # enable/disable entire installation of the kafka-watcher
   repository: otterize
   image: network-mapper-kafka-watcher
-  tag: latest
   pullPolicy:
   pullSecrets:
   resources: { }


### PR DESCRIPTION
### Description

Use chart.appVersion for intents-operator, credentials-operator, and network-mapper, image tags instead of using "latest".