### PR TITLE
Add get permission to the intents-operator clusterRole file

### DIFF
--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -25,6 +25,12 @@ rules:
   - update
   - watch
 - apiGroups:
+    - ""
+  resources:
+    - namespaces
+  verbs:
+    - get
+- apiGroups:
   - ""
   resources:
   - pods


### PR DESCRIPTION
The intents operator will need GET permissions for namespaces to perform get operation on "kube-system"  for its UID (that will be used as cluster identifier).