### PR TITLE
Pin istio-watcher image tag to chart.AppVersion instead of latest

### DIFF
--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -62,7 +62,7 @@ istiowatcher:
   enable: true
   repository: otterize
   image: network-mapper-istio-watcher
-  tag: latest
+  tag:
   pullPolicy:
   pullSecrets:
   resources: { }


### PR DESCRIPTION

### Description

Pin istio-watcher's image tag to the chart's app version instead of the latest tag.

