### PR TITLE
Configure the telemetry flag for both true and false values

### DIFF
--- a/credentials-operator/README.md
+++ b/credentials-operator/README.md
@@ -1,4 +1,4 @@
-# Parameters
+# Parameters 
 
 ## Global parameters
 | Key                                  | Description                                                                                                                                 | Default |

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -48,7 +48,10 @@ spec:
         {{ end }}
         {{- if eq false .Values.global.telemetry.enabled }}
         - --telemetry-enabled=false
+        {{- else }}
+        - --telemetry-enabled=true
         {{- end }}
+
         command:
         - /manager
         image: "{{ .Values.operator.repository }}/{{ .Values.operator.image }}:{{ default $.Chart.AppVersion .Values.operator.tag }}"

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -57,6 +57,9 @@ spec:
             {{- if eq false .Values.global.telemetry.enabled }}
             - names: OTTERIZE_TELEMETRY_ENABLED
               value: false
+            {{- else }}
+            - names: OTTERIZE_TELEMETRY_ENABLED
+              value: true
             {{- end }}
           volumeMounts:
             {{- if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}


### PR DESCRIPTION

### Description

Configure the telemetry flag for both true and false values. This way the helm chart is independent of the app defaults.

### References

https://github.com/otterize/intents-operator/pull/178