### PR TITLE
Add 'update CRD' permission to intents-operator

### DIFF
--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -25,11 +25,11 @@ rules:
   - update
   - watch
 - apiGroups:
-    - ""
+  - ""
   resources:
-    - namespaces
+  - namespaces
   verbs:
-    - get
+  - get
 - apiGroups:
   - ""
   resources:
@@ -57,6 +57,15 @@ rules:
   - list
   - patch
   - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - k8s.otterize.com
   resources:
@@ -142,11 +151,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-    - apiextensions.k8s.io
-  resources:
-    - customresourcedefinitions
-  verbs:
-    - get
-    - list
-    - watch


### PR DESCRIPTION
Changes in resource order result from auto-generating the file from the operator source code instead of manually editing, which also fixed some bad indentations.

