### PR TITLE
add tolerations and priority class name to network-mapper daemon set

### DIFF
--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-mapper
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.1.19
 home: https://github.com/otterize/network-mapper
 sources:

--- a/network-mapper/README.md
+++ b/network-mapper/README.md
@@ -22,7 +22,9 @@
 | `sniffer.pullPolicy`       | Sniffer pull policy.       | `(none)`                 |
 | `sniffer.pullSecrets`      | Sniffer pull secrets.      | `(none)`                 |
 | `sniffer.resources`        | Resources override.        | `(none)`                 |   
-
+| `sniffer.resources`        | Resources override.        | `(none)`                 |
+| `sniffer.tolerations`      | Tolerations ovveride.      | `(none)`                 |   
+| `sniffer.priorityClassName`| Set priorityClassName.     | `(none)`                 |
 
 ## Kafka watcher parameters
 | Key                             | Description                                                 | Default                        |

--- a/network-mapper/README.md
+++ b/network-mapper/README.md
@@ -23,7 +23,7 @@
 | `sniffer.pullSecrets`      | Sniffer pull secrets.      | `(none)`                 |
 | `sniffer.resources`        | Resources override.        | `(none)`                 |   
 | `sniffer.resources`        | Resources override.        | `(none)`                 |
-| `sniffer.tolerations`      | Tolerations ovveride.      | `(none)`                 |   
+| `sniffer.tolerations`      | Tolerations override.      | `(none)`                 |   
 | `sniffer.priorityClassName`| Set priorityClassName.     | `(none)`                 |
 
 ## Kafka watcher parameters

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -16,6 +16,12 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.sniffer.pullSecrets }}
       {{ end }}
+      {{- with .Values.sniffer.tolerations }}
+      tolerations:  {{- toYaml . | nindent 8 }}
+     {{- end }}
+     {{- with .Values.sniffer.priorityClassName }}
+      priorityClassName:  {{ . }}
+     {{- end }}      
       containers:
       - name: {{ template "otterize.sniffer.fullName" . }}
         image: "{{ .Values.sniffer.repository }}/{{ .Values.sniffer.image }}:{{ default $.Chart.AppVersion .Values.sniffer.tag }}"

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -25,6 +25,11 @@ sniffer:
   image: network-mapper-sniffer
   pullPolicy:
   pullSecrets:
+  tolerations: []
+  #The options to add tolerations
+  # tolerations:
+  # - operator: Exists
+  priorityClassName: ""  
   resources: { }
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
### Description
Adding the option to add tolerations and priority class name to network mapper daemon set, so the network mapper could be added to the entire nodes in the cluster
### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
https://github.com/otterize/helm-charts/issues/92


### Checklist

- [  ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
