### PR TITLE
Add SYS_PTRACE capability to network sniffer

### DIFF
--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -35,6 +35,10 @@ spec:
             value: http://{{ template "otterize.mapper.fullName" . }}:9090/query
           - name: OTTERIZE_DEBUG
             value: {{ .Values.debug | quote }}
+        securityContext:
+          capabilities:
+            add:
+              - SYS_PTRACE
         volumeMounts:
           - mountPath: /hostproc
             name: proc


### PR DESCRIPTION
Allows the network sniffer to read the HOSTNAME environment variable, which is used for verifying the pod identity.