### PR TITLE
Add crd create permissions to intents-operator-manager-clusterrole.yaml

### DIFF
--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -66,6 +66,7 @@ rules:
   - list
   - update
   - watch
+  - create
 - apiGroups:
   - k8s.otterize.com
   resources:


### PR DESCRIPTION
### Description

Following the release of "protected-services" feature, the operator needs the permissions to create CRD in order to create the protectedService CRD.


