### PR TITLE
Fix cert-manager file mount locations

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -195,6 +195,15 @@ spec:
       - name: spire-tls
         secret:
           secretName: intents-operator-spire-tls-controller-manager
+          {{ if eq "cert-manager" .Values.global.certificateProvider }}
+          items:
+            - key: tls.crt
+              path: cert.pem
+            - key: tls.key
+              path: key.pem
+            - key: ca.crt
+              path: ca.pem
+          {{ end }}
       {{ end }}
       {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
       - name: api-extra-ca-pem


### PR DESCRIPTION
This PR fixes a bug where the intents operator chart did not mount the TLS certificates in the right location when using cert-manager.