### PR TITLE
Update default certificate path for intents operator

### DIFF
--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 {{- end -}}
 
 {{- define "otterize.operator.cert" -}}
-{{ template "otterize.operator.tlsPath" }}/svid.pem
+{{ template "otterize.operator.tlsPath" }}/cert.pem
 {{- end -}}
 
 {{- define "otterize.operator.key" -}}


### PR DESCRIPTION
Update the default certificate path to reflect that SPIRE is no longer recommended.