### PR TITLE
Remove unused watcher object

### DIFF
--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -32,23 +32,6 @@ operator:
   #   cpu: 100m
   #   memory: 128Mi
 
-watcher:
-  repository: otterize
-  image: intents-operator-pod-watcher
-  pullPolicy:
-
-  resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
 # allowGetAllResources gives get permission to watch on all resources. If disabled, the operator will only
 # be able to resolve pods up to their built-in owners. For example, a Pod is owned by a ReplicaSet that is owned by a Deployment.
 # If that Deployment is owned by a custom resource, the operator will not be able to resolve it.

--- a/otterize-kubernetes/values.yaml
+++ b/otterize-kubernetes/values.yaml
@@ -55,7 +55,6 @@ intentsOperator:
     autoCreateNetworkPoliciesForExternalTraffic: true
     enableIstioPolicyCreation: true
   watchedNamespaces: null # by default, watch all
-  watcher: {}
 
 # alias for spire values
 spire: {}


### PR DESCRIPTION
Pod watcher is no longer an independent deployment