### PR TITLE
Add liveness and readiness checks to mapper components, as well as tighter security context restrictions

### DIFF
--- a/network-mapper/templates/istio-watcher-deployment.yaml
+++ b/network-mapper/templates/istio-watcher-deployment.yaml
@@ -61,5 +61,17 @@ spec:
             - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
               value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}
             {{ end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 20
       serviceAccountName: {{ template "otterize.istiowatcher.fullName" . }}
 {{ end }}

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -40,6 +40,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
       {{ if .Values.kafkawatcher.pullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.kafkawatcher.pullSecrets }}
@@ -65,5 +67,24 @@ spec:
             - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
               value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}
             {{ end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
       serviceAccountName: {{ template "otterize.kafkawatcher.fullName" . }}
 {{ end }}

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -39,6 +39,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
       {{ if .Values.mapper.pullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.mapper.pullSecrets }}
@@ -102,6 +104,18 @@ spec:
               name: api-extra-ca-pem
               readOnly: true
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 20
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -64,7 +64,22 @@ spec:
           - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
             value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}
           {{ end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 5
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          initialDelaySeconds: 5
+          periodSeconds: 20
         securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             add:
               - SYS_PTRACE


### PR DESCRIPTION
Related: https://github.com/otterize/network-mapper/pull/139