### PR TITLE
Increase initialDelaySeconds for mapper components liveness and readiness

### DIFF
--- a/network-mapper/templates/istio-watcher-deployment.yaml
+++ b/network-mapper/templates/istio-watcher-deployment.yaml
@@ -65,13 +65,13 @@ spec:
             httpGet:
               path: /healthz
               port: 9090
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /healthz
               port: 9090
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 20
       serviceAccountName: {{ template "otterize.istiowatcher.fullName" . }}
 {{ end }}

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -71,13 +71,13 @@ spec:
             httpGet:
               path: /healthz
               port: 9090
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /healthz
               port: 9090
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 20
           securityContext:
             privileged: false

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -68,13 +68,13 @@ spec:
           httpGet:
             path: /healthz
             port: 9090
-          initialDelaySeconds: 15
+          initialDelaySeconds: 30
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /healthz
             port: 9090
-          initialDelaySeconds: 15
+          initialDelaySeconds: 30
           periodSeconds: 20
         securityContext:
           privileged: false


### PR DESCRIPTION
On slow Minikube clusters, mapper components could take longer to start, causing data loss initially when they were restarted, which effectively resulted in the network map being slow to populate.