### PR TITLE
Support for configuring the OpenTelemetry exporter

### DIFF
--- a/network-mapper/README.md
+++ b/network-mapper/README.md
@@ -1,16 +1,23 @@
 # Parameters
 
 ## Mapper parameters
-| Key                            | Description                          | Default          |
-|--------------------------------|--------------------------------------|------------------|
-| `mapper.image.repository`      | Mapper image repository.             | `otterize`       |
-| `mapper.image.image`           | Mapper image.                        | `network-mapper` |
-| `mapper.image.tag`             | Mapper image tag.                    | `latest`         |
-| `mapper.pullPolicy`            | Mapper pull policy.                  | `(none)`         |
-| `mapper.pullSecrets`           | Mapper pull secrets.                 | `(none)`         |
-| `mapper.resources`             | Resources override.                  | `(none)`         |
-| `mapper.uploadIntervalSeconds` | Interval for uploading data to cloud | `60`             |
-| `mapper.excludeNamespaces`     | Namespaces excluded from reporting   | `[istio-system]` |
+| Key                            | Description                                                                                     | Default          |
+|--------------------------------|-------------------------------------------------------------------------------------------------|------------------|
+| `mapper.image.repository`      | Mapper image repository.                                                                        | `otterize`       |
+| `mapper.image.image`           | Mapper image.                                                                                   | `network-mapper` |
+| `mapper.image.tag`             | Mapper image tag.                                                                               | `latest`         |
+| `mapper.pullPolicy`            | Mapper pull policy.                                                                             | `(none)`         |
+| `mapper.pullSecrets`           | Mapper pull secrets.                                                                            | `(none)`         |
+| `mapper.resources`             | Resources override.                                                                             | `(none)`         |
+| `mapper.uploadIntervalSeconds` | Interval for uploading data to cloud                                                            | `60`             |
+| `mapper.excludeNamespaces`     | Namespaces excluded from reporting                                                              | `[istio-system]` |
+| `mapper.extraEnvVars`          | List of extra env vars for the mapper, formatted as in the Kubernetes PodSpec (name and value). | `(none)`         |
+
+## OpenTelemetry exporter parameters
+| Key                        | Description                                                                                                                                                                                                     | Default                              |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `opentelemetry.enable`     | Whether to enable the OpenTelemetry exporter, which exports Grafana Tempo-style metrics for your network map. Configure the OpenTelemetry SDK using `mapper.extraEnvVars` (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`). | `false`                              |
+| `opentelemetry.metricName` | The name of the OpenTelemetry metric name exported for the Grafana Tempo-style metric.                                                                                                                          | `traces_service_graph_request_total` |
 
 ## Sniffer parameters
 | Key                        | Description                | Default                  |

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -54,6 +54,14 @@ spec:
           resources:
             {{- toYaml .Values.mapper.resources | nindent 12 }}
           env:
+            {{ if .Values.opentelemetry.enable }}
+            - name: OTTERIZE_ENABLE_OTEL_EXPORT
+              value: "true"
+            {{ end }}
+            {{ if .Values.opentelemetry.metricName }}
+            - name: OTTERIZE_OTEL_METRIC_NAME
+              value: "{{ .Values.opentelemetry.metricName }}"
+            {{ end }}
             - name: OTTERIZE_DEBUG
               value: {{ .Values.debug | quote }}
             {{ if .Values.global.otterizeCloud.apiAddress }}
@@ -97,6 +105,9 @@ spec:
             {{- else }}
             - name: OTTERIZE_TELEMETRY_ENABLED
               value: "true"
+            {{- end }}
+            {{- if .Values.mapper.extraEnvVars -}}
+            {{- toYaml .Values.mapper.extraEnvVars | nindent 12 -}}
             {{- end }}
           volumeMounts:
             {{- if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -1,10 +1,15 @@
 # Local configuration for network mapper chart
+opentelemetry:
+  enable: false
+  metricName: traces_service_graph_request_total
+
 mapper:
   repository: otterize
   image: network-mapper
   pullPolicy:
   pullSecrets:
   resources: { }
+  extraEnvVars:
   excludeNamespaces:
     - 'istio-system'
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
### Description

This PR adds support for configuring the OpenTelemetry exporter that exports Grafana Tempo-style metrics, contributed by @smithclay from Lightstep/ServiceNow in https://github.com/otterize/network-mapper/pull/141.

### References

https://github.com/otterize/network-mapper/pull/141

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
