### PR TITLE
Add configuration for experimental egress network policy support

### DIFF
--- a/intents-operator/README.md
+++ b/intents-operator/README.md
@@ -28,6 +28,8 @@
 | `operator.autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement` | **experimental** - If `autoCreateNetworkPoliciesForExternalTraffic` is enabled, do not require ClientIntents resources - simply create network policies based off of the existence of an Ingress/Service resource.                     | `false`            |
 | `operator.resources`                                                            | Resources override.                                                                                                                                                                                                                    |                    |
 | `operator.enableDatabaseReconciler`                                             | **experimental** - Enables experimental support for database intents (coming soon!)                                                                                                                                                    | `false`            |
+| `operator.enableEgressNetworkPolicyCreation`                                    | **experimental** - Enables experimental support for egress network policies (coming soon!)                                                                                                                                             | `false`            |
+
 
 ## Watcher parameters
 | Key                        | Description                | Default                        |

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -78,6 +78,9 @@ spec:
         {{- if eq true .Values.operator.enableDatabaseReconciler }}
         - --enable-database-reconciler=true
         {{- end }}
+        {{- if eq true .Values.operator.enableEgressNetworkPolicyCreation }}
+        - --exp-enable-egress-network-policies=true
+        {{- end }}
 
         command:
         - /manager

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -19,6 +19,7 @@ operator:
   autoCreateNetworkPoliciesForExternalTrafficDisableIntentsRequirement: false
   enableIstioPolicyCreation: true
   enableDatabaseReconciler: false
+  enableEgressNetworkPolicyCreation: false
 
   resources: { }
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR adds experimental support for the generation of egress network policies, to be used together with an egress default deny policy.

The intents operator can now generate egress network policies to pods, or to pods at specific ports, if a Kubernetes service is targeted using intents.

### References

References
https://github.com/otterize/intents-operator/pull/256

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
