### PR TITLE
Upgrade SPIRE version to a version that was built with ARM64 support

### DIFF
--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -27,8 +27,8 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 1.0.0
-appVersion: "1.5.4"
+version: 1.0.1
+appVersion: "1.8.3"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent"]
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"


### PR DESCRIPTION
### Description

SPIRE version 1.5.4, which our Helm chart used, was not built for ARM64. This PR changes the version to 1.8.3, which was built for ARM64.

### References

https://github.com/otterize/helm-charts/issues/127
