### PR TITLE
Fix helm value name for intents operator

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -142,7 +142,7 @@ spec:
           - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
             value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}
           {{ end }}
-          - name: OTTERIZE_AWS_INTENTS_ENABLED
+          - name: OTTERIZE_ENABLE_AWS_IAM_POLICY
             value: {{ .Values.global.aws.enabled | quote }}
           - name: OTTERIZE_EKS_OIDC_URL
             value: {{ .Values.global.aws.oidcUrl | quote }}


### PR DESCRIPTION
The helm chart used a wrong name to enable AWS integration. This commit changes the name to the correct one.