### PR TITLE
Allow specifying override EKS cluster name; otherwise autodetect from environment

### DIFF
--- a/credentials-operator/templates/deployment.yaml
+++ b/credentials-operator/templates/deployment.yaml
@@ -93,8 +93,9 @@ spec:
         {{ if eq true .Values.global.aws.enabled }}
         - --enable-aws-serviceaccount-management=true
         {{ end }}
-        {{ if .Values.global.aws.oidcUrl }}
-        - --eks-oidc-url={{.Values.global.aws.oidcUrl }}
+        {{ if .Values.global.aws.eksClusterNameOverride }}
+        - name: OTTERIZE_EKS_CLUSTER_NAME_OVERRIDE
+          value: {{ .Values.global.aws.eksClusterNameOverride | quote }}
         {{ end }}
         - --leader-elect
         command:

--- a/credentials-operator/templates/deployment.yaml
+++ b/credentials-operator/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
         {{- end }}
         {{ if eq true .Values.global.aws.enabled }}
         - --enable-aws-serviceaccount-management=true
+        {{ end }}
+        {{ if .Values.global.aws.oidcUrl }}
         - --eks-oidc-url={{.Values.global.aws.oidcUrl }}
         {{ end }}
         - --leader-elect

--- a/credentials-operator/values.yaml
+++ b/credentials-operator/values.yaml
@@ -39,7 +39,7 @@ global:
 
   aws:
     enabled: false
-    oidcUrl:
+    eksClusterNameOverride:
     roleARN:
 
   # Specify an annotation name that by setting it, one can override otterize's service name resolution.

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -144,9 +144,9 @@ spec:
           {{ end }}
           - name: OTTERIZE_ENABLE_AWS_IAM_POLICY
             value: {{ .Values.global.aws.enabled | quote }}
-          {{ if .Values.global.aws.oidcUrl }}
-          - name: OTTERIZE_EKS_OIDC_URL
-            value: {{ .Values.global.aws.oidcUrl | quote }}
+          {{ if .Values.global.aws.eksClusterNameOverride }}
+          - name: OTTERIZE_EKS_CLUSTER_NAME_OVERRIDE
+            value: {{ .Values.global.aws.eksClusterNameOverride | quote }}
           {{ end }}
         volumeMounts:
         - mountPath: /controller_manager_config.yaml

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -144,8 +144,10 @@ spec:
           {{ end }}
           - name: OTTERIZE_ENABLE_AWS_IAM_POLICY
             value: {{ .Values.global.aws.enabled | quote }}
+          {{ if .Values.global.aws.oidcUrl }}
           - name: OTTERIZE_EKS_OIDC_URL
             value: {{ .Values.global.aws.oidcUrl | quote }}
+          {{ end }}
         volumeMounts:
         - mountPath: /controller_manager_config.yaml
           name: manager-config

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -64,7 +64,7 @@ global:
 
   aws:
     enabled: false
-    oidcUrl:
+    eksClusterNameOverride:
 
   # Extra annotations for deployed pods
   podAnnotations: {}

--- a/otterize-kubernetes/values.yaml
+++ b/otterize-kubernetes/values.yaml
@@ -7,7 +7,7 @@ global:
 
   aws:
     enabled: false
-    oidcUrl:
+    eksClusterNameOverride:
 
   # Extra annotations for deployed pods
   podAnnotations: {}


### PR DESCRIPTION
With https://github.com/otterize/intents-operator/pull/290 the cluster name should only be specified for overriding.