### PR TITLE
Revert change without version: Kafka watcher configuration update

### DIFF
--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -67,14 +67,6 @@ spec:
             - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
               value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}
             {{ end }}
-            {{ if .Values.kafkawatcher.kafkaReportInterval }}
-            - name: OTTERIZE_KAFKA_REPORT_INTERVAL
-              value: {{ .Values.kafkawatcher.kafkaReportInterval | quote }}
-            {{ end }}
-            {{ if .Values.kafkawatcher.kafkaCooldownInterval }}
-            - name: OTTERIZE_KAFKA_COOLDOWN_INTERVAL
-              value: {{ .Values.kafkawatcher.kafkaCooldownInterval | quote }}
-            {{ end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -56,10 +56,6 @@ kafkawatcher:
   resources: { }
   # Kafka servers to watch, specified as `pod.namespace` items.
   kafkaServers: []
-  # Interval between reports of watcher results to the network-mapper
-  kafkaReportInterval:
-  # Interval between watcher polls of its Kafka servers
-  kafkaCooldownInterval:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
### Description

This PR revert an update to Kafka watcher values, that was add without an update to chart version to keep the previous version as it was. The changed will be added later with a version update
