### PR TITLE
Expose Kafka report intervals configuration using Helm values

### DIFF
--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-mapper
 type: application
 version: 1.0.0
-appVersion: v1.0.7
+appVersion: v1.0.8
 home: https://github.com/otterize/network-mapper
 sources:
   - https://github.com/otterize/network-mapper

--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: network-mapper
 type: application
-version: 1.0.0
-appVersion: v1.0.8
+version: 1.0.1
+appVersion: v1.0.7
 home: https://github.com/otterize/network-mapper
 sources:
   - https://github.com/otterize/network-mapper

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -67,6 +67,14 @@ spec:
             - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
               value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}
             {{ end }}
+            {{ if .Values.kafkawatcher.kafkaReportInterval }}
+            - name: OTTERIZE_KAFKA_REPORT_INTERVAL
+              value: {{ .Values.kafkawatcher.kafkaReportInterval | quote }}
+            {{ end }}
+            {{ if .Values.kafkawatcher.kafkaCooldownInterval }}
+            - name: OTTERIZE_KAFKA_COOLDOWN_INTERVAL
+              value: {{ .Values.kafkawatcher.kafkaCooldownInterval | quote }}
+            {{ end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -56,6 +56,10 @@ kafkawatcher:
   resources: { }
   # Kafka servers to watch, specified as `pod.namespace` items.
   kafkaServers: []
+  # Interval between reports of watcher results to the network-mapper
+  kafkaReportInterval:
+  # Interval between watcher polls of its Kafka servers
+  kafkaCooldownInterval:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 1.0.1
+version: 1.0.2
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:


### PR DESCRIPTION
### Description
Enable the option to configure Kafka report intervals using Helm values.

### Checklist
This feature is documented only in the chart description since it's a low level feature for testing who shouldn't be changed in normal use.

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
