### PR TITLE
Always deploy credentials operator (required for AWS), declare ports for network mapper

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/service-name: intents-operator
-        {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.deployment.credentialsOperator) }}
+        {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.certificateProvider) }}
         credentials-operator.otterize.com/tls-secret-name: intents-operator-spire-tls-controller-manager
         {{- end }}
         {{- with .Values.global.podAnnotations }}
@@ -60,7 +60,7 @@ spec:
         {{- range .Values.watchedNamespaces }}
         - --watched-namespaces={{ . | quote }}
         {{- end }}
-      {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.deployment.credentialsOperator) }}
+      {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.certificateProvider) }}
         - --kafka-server-tls-cert={{ template "otterize.operator.cert" }}
         - --kafka-server-tls-key={{ template "otterize.operator.key" }}
         - --kafka-server-tls-ca={{ template "otterize.operator.ca" }}
@@ -154,7 +154,7 @@ spec:
           subPath: controller_manager_config.yaml
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
-        {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.deployment.credentialsOperator) }}
+        {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.certificateProvider) }}
         - mountPath: {{ template "otterize.operator.tlsPath" }}
           name: spire-tls
           readOnly: true
@@ -195,7 +195,7 @@ spec:
       - configMap:
           name: intents-operator-manager-config
         name: manager-config
-      {{ if and (or .Values.operator.autoGenerateTLSUsingCredentialsOperator .Values.global.certificateProvider) (.Values.global.deployment.credentialsOperator) }}
+      {{ if and (or .Values.operator.autoGenerateTLSUsingCredentialsOperator .Values.global.certificateProvider) (.Values.global.certificateProvider) }}
       - name: spire-tls
         secret:
           secretName: intents-operator-spire-tls-controller-manager

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -53,6 +53,11 @@ spec:
           {{ end }}
           resources:
             {{- toYaml .Values.mapper.resources | nindent 12 }}
+          ports:
+            - containerPort: 9090
+              name: graphql
+            - containerPort: 2112
+              name: metrics
           env:
             {{ if .Values.opentelemetry.enable }}
             - name: OTTERIZE_ENABLE_OTEL_EXPORT

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,15 +3,13 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 1.0.2
+version: 1.0.3
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:
   - name: credentials-operator
     alias: credentialsOperator
     version: ">= 0.0.1"
-    # condition must have NO spaces or the values are considered invalid and will make this always be true! DO NOT add spaces around the comma!
-    condition: deployment.credentialsOperator,global.deployment.credentialsOperator
     repository: file://./../credentials-operator
   - name: spire
     alias: spire


### PR DESCRIPTION
### Description

Previously, the credentials operator was not deployed by default. This is because to do anything at all, it required a certificate provider - Otterize Cloud, a SPIRE server, or cert-manager. The credentials operator now also manages AWS IAM roles and links Kubernetes service accounts, so it is functional on its own.

This PR also fixes a problem where the Deployment for the network-mapper did not declare its ports.