### PR TITLE
Fix credentials operator deployment documentation, and re-add credentials operator deployment condition with different default

### DIFF
--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -57,7 +57,7 @@ allowGetAllResources: true
 watchedNamespaces: null # by default, watch all
 global:
   deployment:
-    credentialsOperator: false # used to determine whether to require credentials from credentials operator
+    credentialsOperator: true
     spire: false
     intentsOperator: true
     networkMapper: true

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,11 +3,13 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 1.0.4
+version: 1.0.5
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:
   - name: credentials-operator
+    # condition must have NO spaces or the values are considered invalid and will make this always be true! DO NOT add spaces around the comma!
+    condition: global.deployment.credentialsOperator
     alias: credentialsOperator
     version: ">= 0.0.1"
     repository: file://./../credentials-operator

--- a/otterize-kubernetes/README.md
+++ b/otterize-kubernetes/README.md
@@ -2,12 +2,12 @@
 # Parameters
 
 ## Deployment parameters
-| Key                                     | Description                                                                      | Default |
-|-----------------------------------------|----------------------------------------------------------------------------------|---------|
-| `global.deployment.spire`               | Whether or not to deploy SPIRE.  Required for mTLS, if not using Otterize Cloud. | `true`  |
-| `global.deployment.credentialsOperator` | Whether or not to deploy credentials-operator. Required for mTLS.                | `false` |
-| `global.deployment.intentsOperator`     | Whether or not to deploy intents-operator.                                       | `true`  |
-| `global.deployment.networkMapper`       | Whether or not to deploy network-mapper.                                         | `true`  |
+| Key                                     | Description                                                                                                                           | Default |
+|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `global.deployment.spire`               | Whether or not to deploy SPIRE.  Required for mTLS, if not using Otterize Cloud.                                                      | `true`  |
+| `global.deployment.credentialsOperator` | Whether or not to deploy credentials-operator. Required to provision mTLS credentials, database username/password, and AWS IAM roles. | `true`  |
+| `global.deployment.intentsOperator`     | Whether or not to deploy intents-operator.                                                                                            | `true`  |
+| `global.deployment.networkMapper`       | Whether or not to deploy network-mapper.                                                                                              | `true`  |
 
 ## Global parameters
 These parameters are used by multiple charts, and must be kept the same for the correct functioning of the separate components.

--- a/otterize-kubernetes/values.yaml
+++ b/otterize-kubernetes/values.yaml
@@ -1,7 +1,7 @@
 global:
   deployment:
     spire: false
-    credentialsOperator: false
+    credentialsOperator: true
     intentsOperator: true
     networkMapper: true
 


### PR DESCRIPTION
In a previous PR #138, the credentials operator chart was set to default on, since the AWS IAM feature requires it, which makes the credentials-operator useful even if you don't use mTLS.

However, this was done through removing the condition in the otterize-kubernetes chart to depend on the credentials-operator chart, and the documentation was also not updated :(

This PR re-adds the condition so that users can still disable the chart if they want to for whatever reason, and corrects the documentation.