### PR TITLE
Add support for enabling the reporting of Internet-facing traffic

### DIFF
--- a/network-mapper/README.md
+++ b/network-mapper/README.md
@@ -13,6 +13,11 @@
 | `mapper.excludeNamespaces`     | Namespaces excluded from reporting                                                              | `[istio-system]` |
 | `mapper.extraEnvVars`          | List of extra env vars for the mapper, formatted as in the Kubernetes PodSpec (name and value). | `(none)`         |
 
+## Internet-facing traffic reporting
+| Key                                    | Description                                                                                                                 | Default |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|---------|
+| `enableInternetFacingTrafficReporting` | Whether to report internet-facing traffic to Otterize Cloud. This is a temporary flag that will soon be enabled by default. | `false` |
+
 ## OpenTelemetry exporter parameters
 | Key                        | Description                                                                                                                                                                                                     | Default                              |
 |----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: OTTERIZE_API_ADDRESS
               value: "{{ .Values.global.otterizeCloud.apiAddress }}"
             {{ end }}
-            {{ if eq true .Values.captureInternetTraffic }}
+            {{ if .Values.enableInternetFacingTrafficReporting }}
             - name: OTTERIZE_CAPTURE_EXTERNAL_TRAFFIC_ENABLED
               value: "true"
             {{ end }}

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -73,6 +73,10 @@ spec:
             - name: OTTERIZE_API_ADDRESS
               value: "{{ .Values.global.otterizeCloud.apiAddress }}"
             {{ end }}
+            {{ if eq true .Values.captureInternetTraffic }}
+            - name: OTTERIZE_CAPTURE_EXTERNAL_TRAFFIC_ENABLED
+              value: "true"
+            {{ end }}
             {{ if .Values.global.serviceNameOverrideAnnotationName }}
             - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
               value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -2,6 +2,7 @@
 opentelemetry:
   enable: false
   metricName: traces_service_graph_request_total
+enableInternetFacingTrafficReporting: false
 
 mapper:
   repository: otterize
@@ -10,7 +11,6 @@ mapper:
   pullSecrets:
   resources: { }
   extraEnvVars:
-  enableInternetFacingTrafficReporting: false
   excludeNamespaces:
     - 'istio-system'
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -10,6 +10,7 @@ mapper:
   pullSecrets:
   resources: { }
   extraEnvVars:
+  enableInternetFacingTrafficReporting: false
   excludeNamespaces:
     - 'istio-system'
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
### Description

Accompanying PR for https://github.com/otterize/network-mapper/pull/161. This is a temporary flag that enables the Internet-facing traffic reporting.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
