### PR TITLE
Allow reporting errors with context id from sniffer and watchers

### DIFF
--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-mapper
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: v1.0.9
 home: https://github.com/otterize/network-mapper
 sources:

--- a/network-mapper/templates/_helpers.tpl
+++ b/network-mapper/templates/_helpers.tpl
@@ -13,6 +13,9 @@ otterize-network-mapper
 {{- define "otterize.mapper.configMapName" -}}
 otterize-network-mapper-store
 {{- end -}}
+{{- define "otterize.mapper.componentConfigmap" -}}
+otterize-network-mapper-component-config-map
+{{- end -}}
 {{ define "otterize.mapper.port" -}}
 9090
 {{- end -}}

--- a/network-mapper/templates/component-config-map.yaml
+++ b/network-mapper/templates/component-config-map.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "otterize.mapper.componentConfigmap" . }}
+  # labels:
+  #   {{- with .Values.global.commonLabels }}
+  #     {{- toYaml . | nindent 4 }}
+  #     {{- end }}
+  #     app.kubernetes.io/version: {{ .Chart.Version }}
+  # annotations:
+  #   {{- with .Values.global.commonAnnotations }}
+  #     {{- toYaml . | nindent 4 }}
+  #     {{- end }}
+  #     app.kubernetes.io/version: {{ .Chart.Version }}
+data: {}

--- a/network-mapper/templates/istio-watcher-deployment.yaml
+++ b/network-mapper/templates/istio-watcher-deployment.yaml
@@ -106,5 +106,13 @@ spec:
               port: 9090
             initialDelaySeconds: 30
             periodSeconds: 20
+          volumeMounts:
+            - mountPath: /etc/otterize
+              name: component-config
+              readOnly: true
       serviceAccountName: {{ template "otterize.istiowatcher.fullName" . }}
+      volumes:
+        - name: component-config
+          configMap:
+            name: {{ template "otterize.mapper.componentConfigmap" . }}
 {{ end }}

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -131,5 +131,13 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/otterize
+              name: component-config
+              readOnly: true
       serviceAccountName: {{ template "otterize.kafkawatcher.fullName" . }}
+      volumes:
+        - name: component-config
+          configMap:
+            name: {{ template "otterize.mapper.componentConfigmap" . }}
 {{ end }}

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -37,6 +37,15 @@ rules:
       - 'statefulsets'
     verbs:
       - 'get'
+  - apiGroups:
+      - ''
+    resources:
+      - 'configmaps'
+    resourceNames:
+      - {{ template "otterize.mapper.componentConfigmap" . }}
+    verbs:
+      - 'get'
+      - 'update'
 {{ if or (and (eq .Values.global.allowGetAllResources nil) .Values.allowGetAllResources) .Values.global.allowGetAllResources}}
   - apiGroups:
       - '*'

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -150,6 +150,9 @@ spec:
               name: api-extra-ca-pem
               readOnly: true
             {{- end }}
+            - mountPath: /etc/otterize
+              name: component-config
+              readOnly: false
           livenessProbe:
             httpGet:
               path: /healthz
@@ -174,3 +177,6 @@ spec:
           secret:
             secretName: {{ .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
         {{ end }}
+        - name: component-config
+          configMap:
+            name: {{ template "otterize.mapper.componentConfigmap" . }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -124,6 +124,9 @@ spec:
           - mountPath: /hostproc
             name: proc
             readOnly: true
+          - mountPath: /etc/otterize
+            name: component-config
+            readOnly: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       volumes:
@@ -131,4 +134,7 @@ spec:
             path: /proc
             type: ""
           name: proc
+        - name: component-config
+          configMap:
+            name: {{ template "otterize.mapper.componentConfigmap" . }}
 {{ end }}


### PR DESCRIPTION
### Description

Allow sharing the mapper context id with the other components who don't call directly to the control plane.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
