### PR TITLE
Add internet intent type to CRD

### DIFF
--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -216,6 +216,17 @@ spec:
                             - databaseName
                           type: object
                         type: array
+                      internet:
+                        properties:
+                          ips:
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            items:
+                              type: integer
+                            type: array
+                        type: object
                       kafkaTopics:
                         items:
                           properties:
@@ -250,9 +261,8 @@ spec:
                           - kafka
                           - database
                           - aws
+                          - internet
                         type: string
-                    required:
-                      - name
                     type: object
                   type: array
                 service:


### PR DESCRIPTION
### Description

This pull request introduces a new intent type designed to manage access to internet addresses. Specifically, for this intent type, the name field is made optional. Due to the limitations of the CRD schema in enforcing the name field requirement based on intent type, the enforcement of this requirement will be handled in the webhook server logic within the operator repository.

### Checklist

- Documentation: This is part of egress network policy feature which is still experimental and will be documented when the feature is released
