### PR TITLE
Add otterizebot token for version bump

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - david/add-otterizebot-token
 
 jobs:
   bump-chart-versions:
@@ -13,6 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.OTTERIZEBOT_GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Get changed files

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - david/add-otterizebot-token
 
 jobs:
   bump-chart-versions:

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 1.0.8
+version: 1.0.7
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 1.0.7
+version: 1.0.8
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:


### PR DESCRIPTION
### Description

Allow otterizebot to directly bump Helm chart versions on main branch

### Checklist

Documentation: This is part of the ci/cd flow of the repository and does not require additional documentation in the docs
