### PR TITLE
Add RBAC read permissions of `batch/jobs` and `batch/cronjobs` to the mapper, credentials-operator and intents-operator ClusterRoles, for Otterize service id resolving

### DIFF
--- a/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
@@ -76,6 +76,15 @@ rules:
     - watch
     - patch
     - update
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
 {{ if or (and (eq .Values.global.allowGetAllResources nil) .Values.allowGetAllResources) .Values.global.allowGetAllResources}}
   - apiGroups:
       - '*'

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -94,6 +94,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - k8s.otterize.com
   resources:
   - clientintents

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -36,7 +36,18 @@ rules:
       - 'replicasets'
       - 'statefulsets'
     verbs:
-      - 'get'
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ''
     resources:


### PR DESCRIPTION

### Description

Add RBAC read permissions of `batch/jobs` and `batch/cronjobs` to the mapper, credentials-operator and intents-operator clusterRoles, for Otterize service id resolving

### References

https://github.com/otterize/intents-operator/pull/333

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
