### PR TITLE
Seeker815/add servicemonitor

### DIFF
--- a/intents-operator/templates/intents-operator-controller-manager-servicemonitor.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: intents-operator-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- with .Values.global.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app: intents-operator
+    release: prometheus
+  annotations:
+    {{- with .Values.global.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+spec:
+  endpoints:
+  - port: https
+    interval: 30s
+    path: /metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: intents-operator
+  {{- end }}
+  {{- end }}

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -105,3 +105,6 @@ global:
     # (optional) The name of a secret containing a single `CA.pem` file for an extra root CA used to connect to Otterize Cloud.
     # The secret should be placed in the same namespace as the Otterize deployment
     apiExtraCAPEMSecret:
+
+serviceMonitor:
+  enabled: false

--- a/network-mapper/templates/mapper-servicemonitor.yaml
+++ b/network-mapper/templates/mapper-servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- with .Values.serviceMonitor }}
+{{- if .enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mapper
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- with .Values.global.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+    app: otterize-network-mapper
+    release: prometheus
+  annotations:
+    {{- with .Values.global.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+spec:
+  endpoints:
+  - port: http
+    interval: 30s 
+    path: /metrics
+    namespaceSelector:
+      matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: otterize-network-mapper
+  {{- end }}
+  {{- end }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -4,6 +4,9 @@ opentelemetry:
   metricName: traces_service_graph_request_total
 enableInternetFacingTrafficReporting: false
 
+serviceMonitor:
+  enabled: false
+
 mapper:
   repository: otterize
   image: network-mapper


### PR DESCRIPTION

### Description

Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.

Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.

Enable ServiceMonitors resources for intents operator and network mapper which Prometheus can use to scrape metrics endpoints.




### Checklist

- [x] I have updated the values file to enable or disable servicemonitor for the operator
- [x] I have tested the service monitor on local kubernetes setup