### PR TITLE
Add Otterize labels to CRDs and webhooks

### DIFF
--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -1,11 +1,11 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-    "helm.sh/resource-policy": keep
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/part-of: otterize
   name: clientintents.k8s.otterize.com
 spec:
   conversion:
@@ -32,14 +32,10 @@ spec:
           description: ClientIntents is the Schema for the intents API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -146,8 +142,7 @@ spec:
               description: IntentsStatus defines the observed state of ClientIntents
               properties:
                 upToDate:
-                  description: upToDate field reflects whether the client intents have
-                    successfully been applied to the cluster to the state specified
+                  description: upToDate field reflects whether the client intents have successfully been applied to the cluster to the state specified
                   type: boolean
               type: object
           type: object
@@ -161,14 +156,10 @@ spec:
           description: ClientIntents is the Schema for the intents API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -290,13 +281,11 @@ spec:
               description: IntentsStatus defines the observed state of ClientIntents
               properties:
                 observedGeneration:
-                  description: The last generation of the intents that was successfully
-                    reconciled.
+                  description: The last generation of the intents that was successfully reconciled.
                   format: int64
                   type: integer
                 upToDate:
-                  description: upToDate field reflects whether the client intents have
-                    successfully been applied to the cluster to the state specified
+                  description: upToDate field reflects whether the client intents have successfully been applied to the cluster to the state specified
                   type: boolean
               type: object
           type: object

--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    "helm.sh/resource-policy": keep
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/part-of: otterize
   name: kafkaserverconfigs.k8s.otterize.com
 spec:
   conversion:

--- a/intents-operator/crds/protectedservices-customresourcedefinition.yaml
+++ b/intents-operator/crds/protectedservices-customresourcedefinition.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    "helm.sh/resource-policy": keep
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/protectedservices-customresourcedefinition.yaml
+++ b/intents-operator/crds/protectedservices-customresourcedefinition.yaml
@@ -4,8 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-    "helm.sh/resource-policy": keep
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/part-of: otterize
   name: protectedservices.k8s.otterize.com
 spec:
   conversion:

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -4,16 +4,6 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: otterize-intents-operator-manager-role
-  labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-  annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
 rules:
 - apiGroups:
   - ""
@@ -213,13 +203,3 @@ rules:
   - patch
   - update
   - watch
-{{ if or (and (eq .Values.global.allowGetAllResources nil) .Values.allowGetAllResources) .Values.global.allowGetAllResources}}
-- apiGroups:
-    - '*'
-  resources:
-    - '*'
-  verbs:
-    - get
-    - list
-    - watch
-{{ end }}

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -4,6 +4,16 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: otterize-intents-operator-manager-role
+  labels:
+    {{- with .Values.global.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+  annotations:
+    {{- with .Values.global.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
 rules:
 - apiGroups:
   - ""
@@ -203,3 +213,13 @@ rules:
   - patch
   - update
   - watch
+{{ if or (and (eq .Values.global.allowGetAllResources nil) .Values.allowGetAllResources) .Values.global.allowGetAllResources}}
+- apiGroups:
+    - '*'
+  resources:
+    - '*'
+  verbs:
+    - get
+    - list
+    - watch
+{{ end }}

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -2,6 +2,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/part-of: otterize
   name: otterize-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
### Description

Add otterize labels to custom resources and webhooks to allow controllers to filter out and reconcile relevant resources 

### References

[Fix operator redeployment overwrite issues and ensure webhook configs and CRDs consistency](https://github.com/otterize/intents-operator/pull/338)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
