### PR TITLE
Add RBAC watch permissions of `ValidatingWebhookConfiguration` to the intents-operator-manager `ClusterRole`

### DIFF
--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -71,6 +71,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
### Description

The intents-operator reconciles `ValidatingWebhookConfiguration` labeled with Otterize labels to update their CA to the self-signed one created by the Operator.

### References

https://github.com/otterize/intents-operator/pull/344/files

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
