### PR TITLE
Update component-config-map.yaml: Fix comments.

### DIFF
--- a/network-mapper/templates/component-config-map.yaml
+++ b/network-mapper/templates/component-config-map.yaml
@@ -4,13 +4,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "otterize.mapper.componentConfigmap" . }}
   # labels:
-  #   {{- with .Values.global.commonLabels }}
-  #     {{- toYaml . | nindent 4 }}
-  #     {{- end }}
-  #     app.kubernetes.io/version: {{ .Chart.Version }}
+  #   {{- /* with .Values.global.commonLabels */ }}
+  #     {{- /* toYaml . | nindent 4 /* }}
+  #     {{- /* end /* }}
+  #     app.kubernetes.io/version: {{ /* .Chart.Version /* }}
   # annotations:
-  #   {{- with .Values.global.commonAnnotations }}
-  #     {{- toYaml . | nindent 4 }}
-  #     {{- end }}
-  #     app.kubernetes.io/version: {{ .Chart.Version }}
+  #   {{- /* with .Values.global.commonAnnotations /* }}
+  #     {{- /* toYaml . | nindent 4 /* }}
+  #     {{- /* end /* }}
+  #     app.kubernetes.io/version: {{ /* .Chart.Version /* }}
 data: {}


### PR DESCRIPTION
Properly set comments. The way it's currently set, the template still expands and you end up with things like this:

      507 apiVersion: v1
      508 kind: ConfigMap
      509 metadata:
      510   namespace: otterize
      511   name: otterize-network-mapper-component-config-map
      512   # labels:
      513   #
      514   #
      515    app.kubernetes.io/name: otterize
      516    kube_cluster: us1-staging
      517   #
      518   #     app.kubernetes.io/version: 1.0.12
      519   # annotations:
      520   #
      521   #     app.kubernetes.io/version: 1.0.12
      522 data: {}

Please see the [contributing guidelines](CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. This template is based on Auth0's excellent template.

### Description

Fix helm template comments. The current version doesn't render.

See for example: https://github.com/helm/helm/issues/9337


