### PR TITLE
Add support for specifying intents for Internet domain names

### DIFF
--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -220,6 +220,8 @@ spec:
                         type: array
                       internet:
                         properties:
+                          dns:
+                            type: string
                           ips:
                             items:
                               type: string
@@ -285,6 +287,17 @@ spec:
                   description: The last generation of the intents that was successfully reconciled.
                   format: int64
                   type: integer
+                resolvedIPs:
+                  items:
+                    properties:
+                      dns:
+                        type: string
+                      ips:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
                 upToDate:
                   description: upToDate field reflects whether the client intents have successfully been applied to the cluster to the state specified
                   type: boolean

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -14,6 +14,21 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.Version }}
 rules:
   - apiGroups:
+    - k8s.otterize.com
+    resources:
+    - clientintents/status
+    verbs:
+    - get
+    - list
+    - update
+  - apiGroups:
+    - k8s.otterize.com
+    resources:
+    - clientintents
+    verbs:
+    - get
+    - list
+  - apiGroups:
       - ''
     resources:
       - 'endpoints'

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
     verbs:
     - get
     - list
-    - update
+    - patch
   - apiGroups:
     - k8s.otterize.com
     resources:


### PR DESCRIPTION
### Description

This PR expand the ability to specify intents to the internet to support specifying intents to DNS and generate Egress network policies to their IP address. This PR update the CRD and the network mapper RBAC permission to allow it update the ClientIntents status field.

### References

[The intents operator relevant PR
](https://github.com/otterize/intents-operator/pull/353)

### Checklist

Egress is an experimental feature, full documentation will be add once the egress support will be officially released.

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
