### PR TITLE
Generate self signed certificates for network mapper webhook by default

### DIFF
--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -148,7 +148,7 @@ spec:
               value: {{ .Values.global.telemetry.errors.networkMapperApiKey | quote }}
             {{- end }}
             {{- if .Values.aws.visibility.enabled }}
-              name: OTTERIZE_ENABLE_AWS_VISIBILITY_WEBHOOK
+            - name: OTTERIZE_ENABLE_AWS_VISIBILITY_WEBHOOK
               value: "true"
             {{- end }}
             {{- if .Values.webhook.generateSelfSignedCert }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -88,7 +88,7 @@ istiowatcher:
   #   memory: 128Mi
 
 webhook:
-  generateSelfSignedCert: false
+  generateSelfSignedCert: true
 
 debug: false
 allowGetAllResources: true


### PR DESCRIPTION
This commit matches the default setting for generating self signed certificate to those of intents operator and credentials operator (that is, generate by default).