### PR TITLE
Change internet DNS field to Domains list

### DIFF
--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -220,8 +220,10 @@ spec:
                         type: array
                       internet:
                         properties:
-                          dns:
-                            type: string
+                          domains:
+                            items:
+                              type: string
+                            type: array
                           ips:
                             items:
                               type: string


### PR DESCRIPTION
### Description

changing the internet dns name field from:

```
spec:
  calls:
  - type: internet
      dns: api.datadoghq.com
```
to
```
spec:
  calls:
  - type: internet
      domains: 
      - api.datadoghq.com
```
### References

[Intents operator PR](https://github.com/otterize/intents-operator/pull/358)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
