### PR TITLE
Apply the credentials-operator webhook when either IAM providers is enabled

### DIFF
--- a/credentials-operator/templates/credentials-operator-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-mutating-webhook-configuration.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.aws.enabled }}
+{{ if or .Values.global.aws.enabled .Values.global.azure.enabled .Values.global.gcp.enabled}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -22,7 +22,15 @@ webhooks:
     name: pods.credentials-operator.otterize.com
     objectSelector:
       matchLabels:
+        {{- if .Values.global.aws.enabled }}
         "credentials-operator.otterize.com/create-aws-role": "true"
+        {{- end }}
+        {{- if .Values.global.azure.enabled }}
+        "credentials-operator.otterize.com/create-azure-role-assignment": "true"
+        {{- end }}
+        {{- if .Values.global.gcp.enabled }}
+        "credentials-operator.otterize.com/create-gcp-sa": "true"
+        {{- end }}
     rules:
     - apiGroups:
       - ""

--- a/credentials-operator/templates/credentials-operator-webhook-service.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.aws.enabled }}
+{{ if or .Values.global.aws.enabled .Values.global.azure.enabled .Values.global.gcp.enabled}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
### Description
Apply the credentials-operator webhook when either IAM providers is enabled - AWS, GCP or Azure. 
Known issue: this won't work when more than one IAM provider is enabled, but that'll be fixed in a separate task (it requires splitting the webhooks to one for each IAM provider). 
