### PR TITLE
fix SPIRE chart helper spire.fullname pointing to wrong .Values.global.spire.fullNameOverride

### DIFF
--- a/spire/templates/_helpers.tpl
+++ b/spire/templates/_helpers.tpl
@@ -11,7 +11,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "spire.fullname" -}}
-{{- if .Values.global.spire.fullnameOverride }}
+{{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}


### PR DESCRIPTION
### Description
Quick fix for what I consider a typo in the spire chart `templates/_helpers.tpl` `spire.fullname` define:

The if statement was pointing to `.Values.global.spire.fullNameOverride` but the output statement was pointing to `.Values.fullnameOverride`.

This was not allowing me to override 'smoothly' the spire resource names.