### PR TITLE
Add support for AWS IAM RolesAnywhere with cert-manager csi-driver-spiffe, which enables cross-cloud AWS IAM access

### DIFF
--- a/credentials-operator/Chart.yaml
+++ b/credentials-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: credentials-operator
 description: credentials-operator
 type: application
-version: 1.0.19
+version: 1.0.20
 appVersion: v1.2.1
 home: https://github.com/otterize/credentials-operator
 sources:

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -220,10 +220,10 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
-# Only runAsNonRoot when not using rolesAnywhere
-{{- if ne true (default .Values.global.aws.rolesAnywhere.enabled false) }}
+          runAsGroup: 65532
+          runAsUser: 65532
+          fsGroup: 65532
           runAsNonRoot: true
-{{- end }}
           capabilities:
             drop:
              - "ALL"
@@ -263,6 +263,7 @@ spec:
             aws.spiffe.csi.cert-manager.io/trust-anchor: {{ .Values.global.aws.rolesAnywhere.trustAnchorARN | quote }}
             aws.spiffe.csi.cert-manager.io/role: {{ .Values.aws.roleARN | quote }}
             aws.spiffe.csi.cert-manager.io/enable: "true"
+            spiffe.csi.cert-manager.io/fs-group: "65532"
 {{- end }}
       {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
       - name: api-extra-ca-pem

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -190,10 +190,14 @@ spec:
             value: {{ .Values.global.telemetry.errors.credentialsOperatorApiKey | quote }}
           {{- end }}
           {{- if .Values.global.aws.rolesAnywhere.enabled }}
-          - name: OTTERIZE_TRUST_DOMAIN
+          - name: OTTERIZE_ENABLE_AWS_IAM_ROLESANYWHERE
+            value: "true"
+          - name: OTTERIZE_ROLESANYWHERE_SPIFFE_TRUST_DOMAIN
             value: {{ .Values.global.aws.rolesAnywhere.trustDomain | quote }}
-          - name: OTTERIZE_TRUST_ANCHOR_ARN
+          - name: OTTERIZE_ROLESANYWHERE_TRUST_ANCHOR_ARN
             value: {{ .Values.global.aws.rolesAnywhere.trustAnchorARN | quote }}
+          - name: OTTERIZE_ROLESANYWHERE_CLUSTER_NAME
+            value: {{ .Values.global.aws.rolesAnywhere.clusterName | quote }}
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: "/aws-config/credentials"
           - name: AWS_REGION

--- a/credentials-operator/templates/credentials-operator-serviceaccount.yaml
+++ b/credentials-operator/templates/credentials-operator-serviceaccount.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/version: {{ .Chart.Version }}
-    {{ if .Values.global.aws.enabled }}
-    "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the intents operator." .Values.aws.roleARN }}
+    {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
+    "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the credentials operator." .Values.aws.roleARN }}
     {{ end }}
     {{ if .Values.global.azure.enabled }}
     azure.workload.identity/client-id: {{ required "You must specify the ID of the user assigned identity used by the credentials operator." .Values.azure.userAssignedIdentityID }}

--- a/intents-operator/Chart.yaml
+++ b/intents-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: intents-operator
 description: Otterize intents operator
 type: application
-version: 1.0.32
+version: 1.0.33
 appVersion: v1.1.12
 home: https://github.com/otterize/intents-operator
 sources:

--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize
   name: clientintents.k8s.otterize.com
@@ -32,10 +31,19 @@ spec:
           description: ClientIntents is the Schema for the intents API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -142,7 +150,9 @@ spec:
               description: IntentsStatus defines the observed state of ClientIntents
               properties:
                 upToDate:
-                  description: upToDate field reflects whether the client intents have successfully been applied to the cluster to the state specified
+                  description: |-
+                    upToDate field reflects whether the client intents have successfully been applied
+                    to the cluster to the state specified
                   type: boolean
               type: object
           type: object
@@ -156,10 +166,19 @@ spec:
           description: ClientIntents is the Schema for the intents API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -310,7 +329,9 @@ spec:
                     type: object
                   type: array
                 upToDate:
-                  description: upToDate field reflects whether the client intents have successfully been applied to the cluster to the state specified
+                  description: |-
+                    upToDate field reflects whether the client intents have successfully been applied
+                    to the cluster to the state specified
                   type: boolean
               type: object
           type: object

--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize
   name: kafkaserverconfigs.k8s.otterize.com
@@ -33,10 +32,19 @@ spec:
           description: KafkaServerConfig is the Schema for the kafkaserverconfigs API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -46,7 +54,9 @@ spec:
                 addr:
                   type: string
                 noAutoCreateIntentsForOperator:
-                  description: If Intents for network policies are enabled, and there are other Intents to this Kafka server, will automatically create an Intent so that the Intents Operator can connect. Set to true to disable.
+                  description: |-
+                    If Intents for network policies are enabled, and there are other Intents to this Kafka server,
+                    will automatically create an Intent so that the Intents Operator can connect. Set to true to disable.
                   type: boolean
                 service:
                   properties:
@@ -104,10 +114,19 @@ spec:
           description: KafkaServerConfig is the Schema for the kafkaserverconfigs API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -117,7 +136,9 @@ spec:
                 addr:
                   type: string
                 noAutoCreateIntentsForOperator:
-                  description: If Intents for network policies are enabled, and there are other Intents to this Kafka server, will automatically create an Intent so that the Intents Operator can connect. Set to true to disable.
+                  description: |-
+                    If Intents for network policies are enabled, and there are other Intents to this Kafka server,
+                    will automatically create an Intent so that the Intents Operator can connect. Set to true to disable.
                   type: boolean
                 service:
                   properties:

--- a/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/protectedservices-customresourcedefinition.yaml
+++ b/intents-operator/crds/protectedservices-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/protectedservices-customresourcedefinition.yaml
+++ b/intents-operator/crds/protectedservices-customresourcedefinition.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize
   name: protectedservices.k8s.otterize.com
@@ -33,10 +32,19 @@ spec:
           description: ProtectedService is the Schema for the protectedservice API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -60,10 +68,19 @@ spec:
           description: ProtectedService is the Schema for the protectedservice API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/version: {{ .Chart.Version }}
-    {{ if .Values.global.aws.enabled }}
-    "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the credentials operator." .Values.aws.roleARN }}
+    {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
+    "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the intents operator." .Values.aws.roleARN }}
     {{ end }}
     {{ if .Values.global.azure.enabled }}
     azure.workload.identity/client-id: {{ required "You must specify the ID of the user assigned identity used by the intents operator." .Values.azure.userAssignedIdentityID }}

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -199,10 +199,14 @@ spec:
             value: "true"
           {{- end }}
           {{- if .Values.global.aws.rolesAnywhere.enabled }}
-          - name: OTTERIZE_TRUST_DOMAIN
+          - name: OTTERIZE_ENABLE_AWS_IAM_ROLESANYWHERE
+            value: "true"
+          - name: OTTERIZE_ROLESANYWHERE_SPIFFE_TRUST_DOMAIN
             value: {{ .Values.global.aws.rolesAnywhere.trustDomain | quote }}
-          - name: OTTERIZE_TRUST_ANCHOR_ARN
+          - name: OTTERIZE_ROLESANYWHERE_TRUST_ANCHOR_ARN
             value: {{ .Values.global.aws.rolesAnywhere.trustAnchorARN | quote }}
+          - name: OTTERIZE_ROLESANYWHERE_CLUSTER_NAME
+            value: {{ .Values.global.aws.rolesAnywhere.clusterName | quote }}
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: "/aws-config/credentials"
           - name: AWS_REGION

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -253,10 +253,10 @@ spec:
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
-# Only runAsNonRoot when not using rolesAnywhere
-{{- if ne true (default .Values.global.aws.rolesAnywhere.enabled false) }}
+          runAsGroup: 65532
+          runAsUser: 65532
+          fsGroup: 65532
           runAsNonRoot: true
-{{- end }}
       serviceAccountName: intents-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
@@ -292,5 +292,6 @@ spec:
             aws.spiffe.csi.cert-manager.io/trust-anchor: {{ .Values.global.aws.rolesAnywhere.trustAnchorARN | quote }}
             aws.spiffe.csi.cert-manager.io/role: {{ .Values.aws.roleARN | quote }}
             aws.spiffe.csi.cert-manager.io/enable: "true"
+            spiffe.csi.cert-manager.io/fs-group: "65532"
 {{- end }}
       - name: cert

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: otterize-intents-operator-manager-role
 rules:
 - apiGroups:
@@ -51,6 +50,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -1,8 +1,8 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   labels:
+    app.kubernetes.io/component: intents-operator
     app.kubernetes.io/part-of: otterize
   name: otterize-validating-webhook-configuration
 webhooks:

--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-mapper
 type: application
-version: 1.0.19
+version: 1.0.20
 appVersion: v1.1.5
 home: https://github.com/otterize/network-mapper
 sources:

--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-mapper
 type: application
 version: 1.0.19
-appVersion: v1.1.4
+appVersion: v1.1.5
 home: https://github.com/otterize/network-mapper
 sources:
   - https://github.com/otterize/network-mapper

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 1.0.58
+version: 1.0.59
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 1.0.55
+version: 1.0.56
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:


### PR DESCRIPTION
This PR adds support for creating AWS IAM RolesAnywhere profiles based on a configured RolesAnywhere Trust Anchor (CA cert) and SPIFFE trust domain, both managed by cert-manager.

When combined with the credentials-operator and the instructions in https://github.com/otterize/otterize-csi-spiffe-demo, this can be used to achieve simple cross-cloud access.

This also temporarily brings back the old code that was moved to credentials.go in the intents-operator.

Related:
* https://github.com/otterize/intents-operator/pull/372
* https://github.com/otterize/credentials-operator/pull/117