### PR TITLE
Rename create-azure-role-assignment label to create-azure-workload-identity for compatibility with other IAM providers

### DIFF
--- a/credentials-operator/templates/credentials-operator-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-mutating-webhook-configuration.yaml
@@ -26,7 +26,7 @@ webhooks:
         "credentials-operator.otterize.com/create-aws-role": "true"
         {{- end }}
         {{- if .Values.global.azure.enabled }}
-        "credentials-operator.otterize.com/create-azure-role-assignment": "true"
+        "credentials-operator.otterize.com/create-azure-workload-identity": "true"
         {{- end }}
         {{- if .Values.global.gcp.enabled }}
         "credentials-operator.otterize.com/create-gcp-sa": "true"


### PR DESCRIPTION
### Description
Rename create-azure-role-assignment label to create-azure-workload-identity for compatibility with other IAM providers


### References
https://github.com/otterize/intents-operator/pull/378

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
