### PR TITLE
 Add additional permissions for Google Cloud to the service account controller

### DIFF
--- a/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
@@ -15,45 +15,37 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.Version }}
 rules:
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - events
-    - serviceaccounts
+      - events
     verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
-    - watch
-    - delete
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
-    - ''
+      - ""
     resources:
-    - namespaces
+      - namespaces
     verbs:
-    - get
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - pods
+      - serviceaccounts
     verbs:
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - secrets
-    verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
-    - watch
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - admissionregistration.k8s.io
     resources:
@@ -64,27 +56,77 @@ rules:
       - patch
       - update
   - apiGroups:
-    - apps
+      - apps
     resources:
-    - replicasets
-    - daemonsets
-    - statefulsets
-    - deployments
-    verbs:
-    - get
-    - list
-    - watch
-    - patch
-    - update
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - jobs
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
     verbs:
       - get
       - list
+      - patch
+      - update
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+{{ if .Values.global.gcp.enabled }}
+  - apiGroups:
+      - iam.cnrm.cloud.google.com
+    resources:
+      - iamserviceaccountkeys
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - iam.cnrm.cloud.google.com
+    resources:
+      - iamserviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - iam.cnrm.cloud.google.com
+    resources:
+      - iampolicymembers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+{{ end }}
 {{ if or (and (eq .Values.global.allowGetAllResources nil) .Values.allowGetAllResources) .Values.global.allowGetAllResources}}
   - apiGroups:
       - '*'


### PR DESCRIPTION
### Description

Add additional permissions for Google Cloud to the service account controller to be able to modify namespaces and cloud config CRDs

