### PR TITLE
Fix network mapper webhook component label

### DIFF
--- a/network-mapper/templates/visibility-dns-webhook-config.yaml
+++ b/network-mapper/templates/visibility-dns-webhook-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-aws-visibility-mutating-webhook-configuration
   labels:
     app.kubernetes.io/part-of: otterize
-    app.kubernetes.io/component: credentials-operator
+    app.kubernetes.io/component: network-mapper
     {{- with .Values.global.commonLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
The network mapper mutating webhook had the wrong component label, creating wrong certificates.
