### PR TITLE
Azure Key Vault policy support #390

### DIFF
--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -215,7 +215,7 @@ spec:
                         items:
                           type: string
                         type: array
-                      azureKeyVaultPermissions:
+                      azureKeyVaultPolicy:
                         properties:
                           certificatePermissions:
                             items:

--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -215,6 +215,91 @@ spec:
                         items:
                           type: string
                         type: array
+                      azureKeyVaultPermissions:
+                        properties:
+                          certificatePermissions:
+                            items:
+                              enum:
+                                - all
+                                - backup
+                                - create
+                                - delete
+                                - deleteissuers
+                                - get
+                                - getissuers
+                                - import
+                                - list
+                                - listissuers
+                                - managecontacts
+                                - manageissuers
+                                - purge
+                                - recover
+                                - restore
+                                - setissuers
+                                - update
+                              type: string
+                            type: array
+                          keyPermissions:
+                            items:
+                              enum:
+                                - all
+                                - backup
+                                - create
+                                - decrypt
+                                - delete
+                                - encrypt
+                                - get
+                                - getrotationpolicy
+                                - import
+                                - list
+                                - purge
+                                - recover
+                                - release
+                                - restore
+                                - rotate
+                                - setrotationpolicy
+                                - sign
+                                - unwrapkey
+                                - update
+                                - verify
+                                - wrapkey
+                              type: string
+                            type: array
+                          secretPermissions:
+                            items:
+                              enum:
+                                - all
+                                - backup
+                                - delete
+                                - get
+                                - list
+                                - purge
+                                - recover
+                                - restore
+                                - set
+                              type: string
+                            type: array
+                          storagePermissions:
+                            items:
+                              enum:
+                                - all
+                                - backup
+                                - delete
+                                - deletesas
+                                - get
+                                - getsas
+                                - list
+                                - listsas
+                                - purge
+                                - recover
+                                - regeneratekey
+                                - restore
+                                - set
+                                - setsas
+                                - update
+                              type: string
+                            type: array
+                        type: object
                       azureRoles:
                         items:
                           type: string

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -103,6 +103,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - iam.cnrm.cloud.google.com
+  resources:
+  - iampartialpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - k8s.otterize.com
   resources:
   - clientintents
@@ -213,17 +225,3 @@ rules:
   - patch
   - update
   - watch
-{{ if .Values.global.gcp.enabled }}
-- apiGroups:
-    - iam.cnrm.cloud.google.com
-  resources:
-    - iampartialpolicies
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-{{ end }}

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -4,93 +4,85 @@ metadata:
   labels:
     app.kubernetes.io/component: intents-operator
     app.kubernetes.io/part-of: otterize
-    {{- with .Values.global.commonLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-  annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
   name: otterize-validating-webhook-configuration
 webhooks:
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: intents-operator-webhook-service
-        namespace: {{ .Release.Namespace }}
-        path: /validate-k8s-otterize-com-v1alpha2-clientintents
-    failurePolicy: Fail
-    name: clientintents.kb.io
-    rules:
-      - apiGroups:
-          - k8s.otterize.com
-        apiVersions:
-          - v1alpha2
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - clientintents
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: intents-operator-webhook-service
-        namespace: {{ .Release.Namespace }}
-        path: /validate-k8s-otterize-com-v1alpha3-clientintents
-    failurePolicy: Fail
-    name: clientintentsv1alpha3.kb.io
-    rules:
-      - apiGroups:
-          - k8s.otterize.com
-        apiVersions:
-          - v1alpha3
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - clientintents
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: intents-operator-webhook-service
-        namespace: {{ .Release.Namespace }}
-        path: /validate-k8s-otterize-com-v1alpha2-protectedservice
-    failurePolicy: Fail
-    name: protectedservice.kb.io
-    rules:
-      - apiGroups:
-          - k8s.otterize.com
-        apiVersions:
-          - v1alpha2
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - protectedservice
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: intents-operator-webhook-service
-        namespace: {{ .Release.Namespace }}
-        path: /validate-k8s-otterize-com-v1alpha3-protectedservice
-    failurePolicy: Fail
-    name: protectedservicev1alpha3.kb.io
-    rules:
-      - apiGroups:
-          - k8s.otterize.com
-        apiVersions:
-          - v1alpha3
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - protectedservice
-    sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v1alpha2-clientintents
+  failurePolicy: Fail
+  name: clientintents.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clientintents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v1alpha3-clientintents
+  failurePolicy: Fail
+  name: clientintentsv1alpha3.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clientintents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v1alpha2-protectedservice
+  failurePolicy: Fail
+  name: protectedservice.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - protectedservice
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v1alpha3-protectedservice
+  failurePolicy: Fail
+  name: protectedservicev1alpha3.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - protectedservice
+  sideEffects: None


### PR DESCRIPTION
### Description

Support Azure Key Vault access policy in ClientIntents. 

Example intents:

```yaml
apiVersion: k8s.otterize.com/v1alpha3
kind: ClientIntents
metadata:
  name: client
  namespace: otterize-tutorial-azure-iam
spec:
  service:
    name: client
  calls:
    - name: "/providers/Microsoft.KeyVault/vaults/testkeyvault" 
      type: azure
      azureKeyVaultPolicy:
        certificatePermissions:
          - "all"
        keyPermissions:
          - "all"
        secretPermissions:
          - "all"
        storagePermissions:
          - "get"
          - "delete"
```

### References
https://github.com/otterize/intents-operator/pull/390

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
