### PR TITLE
Remove double quotes from annotations

### DIFF
--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/postgresqlserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/crds/postgresqlserverconfigs-customresourcedefinition.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize

--- a/intents-operator/crds/protectedservices-customresourcedefinition.yaml
+++ b/intents-operator/crds/protectedservices-customresourcedefinition.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-    "helm.sh/resource-policy": keep
+    helm.sh/resource-policy: keep
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: otterize


### PR DESCRIPTION
### Description

The double quotes have no effect and the file is generated by `kustomize` without them.
