### PR TITLE
Remove duplicate instance of `app.kubernetes.io/component`

### DIFF
--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: intents-operator
     app.kubernetes.io/part-of: otterize
-    app.kubernetes.io/component: intents-operator
   name: otterize-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
Please see the [contributing guidelines](CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. This template is based on Auth0's excellent template.

### Description

It seems there's a duplicate of the `app.kubernetes.io/component` label in the ValidatingWebhook for the intents-operator. This might not cause issues for deploying to Kubernetes, but it's causing my Kpt pipeline to fail. I hope there aren't any extra changes i must make for a PR. Otherwise tell me, and i'll add it to the branch :)

### Checklist

- [N/A] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
