### PR TITLE
Support for passing extraEnvVars for intents-operator & credentials-operator (previously only supported for network-mapper)

### DIFF
--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -206,6 +206,9 @@ spec:
           - name: OTTERIZE_USE_IMAGE_NAME_FOR_SERVICE_ID_FOR_JOBS
             value: "true"
           {{- end }}
+          {{- if .Values.operator.extraEnvVars -}}
+          {{- toYaml .Values.operator.extraEnvVars | nindent 12 -}}
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/credentials-operator/values.yaml
+++ b/credentials-operator/values.yaml
@@ -2,6 +2,7 @@ operator:
   repository: otterize
   image: credentials-operator
   pullPolicy:
+  extraEnvVars:
 
 resources: { }
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -211,6 +211,9 @@ spec:
           - name: OTTERIZE_USE_IMAGE_NAME_FOR_SERVICE_ID_FOR_JOBS
             value: "true"
           {{- end }}
+          {{- if .Values.operator.extraEnvVars -}}
+          {{- toYaml .Values.operator.extraEnvVars | nindent 12 -}}
+          {{- end }}
         volumeMounts:
 {{- if .Values.global.aws.rolesAnywhere.enabled }}
         - mountPath: /aws-config

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -33,6 +33,7 @@ operator:
   enableIstioPolicyCreation: true
   enableDatabasePolicyCreation: true
   enableEgressNetworkPolicyCreation: false
+  extraEnvVars:
 
   resources: { }
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
### Description

Support passing extraEnvVars on all three components. Used for specifying HTTP_PROXY, HTTPS_PROXY, etc.