### PR TITLE
Enable DNS intents support by default

### DIFF
--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -158,9 +158,9 @@ spec:
             - name: OTTERIZE_CREATE_WEBHOOK_CERTIFICATE
               value: "true"
             {{- end }}
-            {{- if .Values.dnsClientIntentsUpdateEnabled }}
+            {{- if eq false .Values.dnsClientIntentsUpdateEnabled }}
             - name: OTTERIZE_DNS_CLIENT_INTENTS_UPDATE_ENABLED
-              value: "true"
+              value: "false"
             {{- end }}
             {{- if .Values.enableIstioCollection }}
             - name: OTTERIZE_ENABLE_ISTIO_COLLECTION

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -161,6 +161,9 @@ spec:
             {{- if eq false .Values.dnsClientIntentsUpdateEnabled }}
             - name: OTTERIZE_DNS_CLIENT_INTENTS_UPDATE_ENABLED
               value: "false"
+            {{- else }}
+            - name: OTTERIZE_DNS_CLIENT_INTENTS_UPDATE_ENABLED
+              value: "true"
             {{- end }}
             {{- if .Values.enableIstioCollection }}
             - name: OTTERIZE_ENABLE_ISTIO_COLLECTION

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -154,9 +154,9 @@ spec:
             - name: OTTERIZE_ENABLE_AWS_VISIBILITY_WEBHOOK
               value: "true"
             {{- end }}
-            {{- if .Values.webhook.generateSelfSignedCert }}
+            {{- if eq false .Values.webhook.generateSelfSignedCert }}
             - name: OTTERIZE_CREATE_WEBHOOK_CERTIFICATE
-              value: "true"
+              value: "false"
             {{- end }}
             {{- if .Values.dnsClientIntentsUpdateEnabled }}
             - name: OTTERIZE_DNS_CLIENT_INTENTS_UPDATE_ENABLED

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -154,9 +154,9 @@ spec:
             - name: OTTERIZE_ENABLE_AWS_VISIBILITY_WEBHOOK
               value: "true"
             {{- end }}
-            {{- if eq false .Values.webhook.generateSelfSignedCert }}
+            {{- if .Values.webhook.generateSelfSignedCert }}
             - name: OTTERIZE_CREATE_WEBHOOK_CERTIFICATE
-              value: "false"
+              value: "true"
             {{- end }}
             {{- if .Values.dnsClientIntentsUpdateEnabled }}
             - name: OTTERIZE_DNS_CLIENT_INTENTS_UPDATE_ENABLED

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -3,7 +3,7 @@ opentelemetry:
   enable: false
   metricName: traces_service_graph_request_total
 enableInternetFacingTrafficReporting: true
-dnsClientIntentsUpdateEnabled: false
+dnsClientIntentsUpdateEnabled: true
 enableIstioCollection: true
 
 mapper:


### PR DESCRIPTION
### Description

The mapper should by default update client intents with DNS resolution data to support intents to domain names server. It was only disabled by default until the full support of egress feature.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
