### PR TITLE
Support specifying `kind` in `ClientIntents` (both for `spec.service` and `spec.calls.call`), `ProtectedServices`, and `KafkaServerConfigs`

### DIFF
--- a/intents-operator/crds/clientintents-customresourcedefinition.yaml
+++ b/intents-operator/crds/clientintents-customresourcedefinition.yaml
@@ -372,6 +372,8 @@ spec:
                             - operations
                           type: object
                         type: array
+                      kind:
+                        type: string
                       name:
                         type: string
                       type:
@@ -388,6 +390,8 @@ spec:
                   type: array
                 service:
                   properties:
+                    kind:
+                      type: string
                     name:
                       type: string
                   required:

--- a/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
+++ b/intents-operator/crds/kafkaserverconfigs-customresourcedefinition.yaml
@@ -144,6 +144,8 @@ spec:
                   type: boolean
                 service:
                   properties:
+                    kind:
+                      type: string
                     name:
                       type: string
                   required:

--- a/intents-operator/crds/protectedservices-customresourcedefinition.yaml
+++ b/intents-operator/crds/protectedservices-customresourcedefinition.yaml
@@ -89,6 +89,8 @@ spec:
             spec:
               description: ProtectedServiceSpec defines the desired state of ProtectedService
               properties:
+                kind:
+                  type: string
                 name:
                   type: string
               type: object


### PR DESCRIPTION
### Description

Support specifying kind in ClientIntents (both for the calls and the service), ProtectedServices, and KafkaServerConfigs. By doing so we are solving an ambiguity problem caused by the service identity resolution mechanism we used (service identity == pod owner name and namespace).

This change is the first of a series of modifications aimed at improving and simplifying the use and comprehensibility of Otterize's IBAC.

### References

https://github.com/otterize/intents-operator/pull/409

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
