### PR TITLE
Bugfix: fix "Tag version" step in bump-version workflow - input tag message

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -72,5 +72,5 @@ jobs:
       - name: Tag version
         run: |
           tag="v${{ steps.bump-versions.outputs.otterize-kubernetes-version }}"
-          git tag -a ${tag}
+          git tag -a ${tag} -m "${tag}"
           git push origin ${tag}


### PR DESCRIPTION
### Description
Bugfix: fix "Tag version" step in bump-version workflow - input tag message

### References
Fixes a bug in https://github.com/otterize/helm-charts/pull/217