### PR TITLE
CoreDNS & IAMlive resource limits/requests

### DIFF
--- a/network-mapper/README.md
+++ b/network-mapper/README.md
@@ -68,6 +68,7 @@ Deployed only when `aws.visibility.enabled` is set to `true`.
 | `iamlive.tag`                      | IAMLive image tag.                   | (pinned to latest version as of this Helm chart version's publish) |
 | `iamlive.pullPolicy`               | IAMLive pull policy.                 | `(none)`                                                           |
 | `iamlive.pullSecrets`              | IAMLive pull secrets.                | `(none)`                                                           |
+| `iamlive.resources`                | Resources override.                  | `(none)`                                                           |
 
 ## DNS visibility parameters
 Deployed only when `aws.visibility.enabled` is set to `true`.
@@ -81,7 +82,7 @@ Deployed only when `aws.visibility.enabled` is set to `true`.
 | `visibilitydns.tag`                      | Image tag.                           | `latest`                |
 | `visibilitydns.pullPolicy`               | Pull policy.                         | `(none)`                |
 | `visibilitydns.pullSecrets`              | Pull secrets.                        | `(none)`                |
-
+| `visibilitydns.resources`                | Resources override.                  | `(none)`                |
 
 ## Cloud parameters
 | Key                                                        | Description                                                                                                                                                                                  | Default  |

--- a/network-mapper/templates/iamlive-deployment.yaml
+++ b/network-mapper/templates/iamlive-deployment.yaml
@@ -58,4 +58,6 @@ spec:
           securityContext:
             {{- toYaml .Values.iamlive.containerSecurityContext | nindent 12 }}
           {{- end }}
+          resources:
+            {{- toYaml .Values.iamlive.resources | nindent 12 }}
 {{ end }}

--- a/network-mapper/templates/visibility-dns-deployment.yaml
+++ b/network-mapper/templates/visibility-dns-deployment.yaml
@@ -57,6 +57,8 @@ spec:
           securityContext:
             {{- toYaml .Values.visibilitydns.containerSecurityContext | nindent 12 }}
           {{- end }}
+          resources:
+            {{- toYaml .Values.visibilitydns.resources | nindent 12 }}
           args:
             - "-conf"
             - "/etc/coredns/Corefile"

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -125,6 +125,7 @@ iamlive:
       drop:
         - "ALL"
   pullSecrets:
+  resources: { } # see comment under mapper.resources
 
 visibilitydns:
   repository: coredns
@@ -134,6 +135,7 @@ visibilitydns:
   podSecurityContext:
   containerSecurityContext:
   pullSecrets:
+  resources: { } # see comment under mapper.resources
 
 aws:
   visibility:


### PR DESCRIPTION
This pull request adds a helm value for network-mapper to override IAMLive & the Visibility CoreDNS deployments resource requests/limits.