### PR TITLE
Add workflow_dispatch trigger to e2e-tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -7,6 +7,17 @@ on:
       - reopened
       - ready_for_review
       - labeled
+  workflow_dispatch:
+    inputs:
+      gcr-registry:
+        required: false
+        type: string
+      intents-operator-tag:
+        required: false
+        type: string
+      credentials-operator-tag:
+        required: false
+        type: string
   workflow_call:
     inputs:
       github_ref:


### PR DESCRIPTION
### Description

Add workflow_dispatch trigger to e2e-tests workflow, to support executing them manually with custom operator tags. 