### PR TITLE
Release new API versions: `v1` (promotion of `v1alpha3`) and `v2alpha1`

### DIFF
--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -33,6 +33,27 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v1-clientintents
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: clientintentsv1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clientintents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /validate-k8s-otterize-com-v1alpha3-clientintents
   failurePolicy: Fail
   matchPolicy: Exact
@@ -96,6 +117,27 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v1-mysqlserverconfig
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: mysqlserverconfigv1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - mysqlserverconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-k8s-otterize-com-v2alpha1-mysqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
@@ -115,8 +157,8 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: intents-operator-webhook-service
-      namespace: {{ .Release.Namespace }}
+      name: webhook-service
+      namespace: system
       path: /validate-k8s-otterize-com-v1alpha3-postgresqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
@@ -126,6 +168,27 @@ webhooks:
     - k8s.otterize.com
     apiVersions:
     - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - postgresqlserverconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-k8s-otterize-com-v1-postgresqlserverconfig
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: postgresqlserverconfigv1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1
     operations:
     - CREATE
     - UPDATE
@@ -168,6 +231,27 @@ webhooks:
     - k8s.otterize.com
     apiVersions:
     - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - protectedservice
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-k8s-otterize-com-v1-protectedservice
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: protectedservicev1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v1
     operations:
     - CREATE
     - UPDATE

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -14,6 +14,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /validate-k8s-otterize-com-v1alpha2-clientintents
   failurePolicy: Fail
+  matchPolicy: Exact
   name: clientintents.kb.io
   rules:
   - apiGroups:
@@ -34,6 +35,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /validate-k8s-otterize-com-v1alpha3-clientintents
   failurePolicy: Fail
+  matchPolicy: Exact
   name: clientintentsv1alpha3.kb.io
   rules:
   - apiGroups:
@@ -52,8 +54,30 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v2alpha1-clientintents
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: clientintentsv2alpha1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clientintents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /validate-k8s-otterize-com-v1alpha3-mysqlserverconfig
   failurePolicy: Fail
+  matchPolicy: Exact
   name: mysqlserverconfig.kb.io
   rules:
   - apiGroups:
@@ -72,8 +96,30 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v2alpha1-mysqlserverconfig
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: mysqlserverconfigv2alpha1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - mysqlserverconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /validate-k8s-otterize-com-v1alpha3-postgresqlserverconfig
   failurePolicy: Fail
+  matchPolicy: Exact
   name: postgresqlserverconfig.kb.io
   rules:
   - apiGroups:
@@ -90,10 +136,32 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: intents-operator-webhook-service
-      namespace: {{ .Release.Namespace }}
+      name: webhook-service
+      namespace: system
+      path: /validate-k8s-otterize-com-v2alpha1-postgresqlserverconfig
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: postgresqlserverconfigv2alpha1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - postgresqlserverconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-k8s-otterize-com-v1alpha2-protectedservice
   failurePolicy: Fail
+  matchPolicy: Exact
   name: protectedservice.kb.io
   rules:
   - apiGroups:
@@ -110,16 +178,38 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: intents-operator-webhook-service
-      namespace: {{ .Release.Namespace }}
+      name: webhook-service
+      namespace: system
       path: /validate-k8s-otterize-com-v1alpha3-protectedservice
   failurePolicy: Fail
+  matchPolicy: Exact
   name: protectedservicev1alpha3.kb.io
   rules:
   - apiGroups:
     - k8s.otterize.com
     apiVersions:
     - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - protectedservice
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-k8s-otterize-com-v2alpha1-protectedservice
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: protectedservicev2alpha1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2alpha1
     operations:
     - CREATE
     - UPDATE


### PR DESCRIPTION


### Description

Update validation webhooks from the new API versions.

### References

Include any links supporting this change such as a:

- GitHub Issue/PR number addressed or fixed
- StackOverflow post
- Related pull requests/issues from other repos

If there are no references, simply delete this section.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
