### PR TITLE
Fix README 'release' badge status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Otterize Helm Charts
 
-![build](https://github.com/otterize/helm-charts/actions/workflows/release.yaml/badge.svg)
+![build](https://github.com/otterize/helm-charts/actions/workflows/release.yaml/badge.svg?branch=)
 ![test](https://github.com/otterize/helm-charts/actions/workflows/e2e-test.yaml/badge.svg)
 [![community](https://img.shields.io/badge/slack-Otterize_Slack-purple.svg?logo=slack)](https://joinslack.otterize.com)
 


### PR DESCRIPTION
### Description
Fix the 'release' badge status shown in the README file. 
This was broken because the release action now happens on tags, and not on main, and so the reference to the default branch name (main) was broken. 

### References
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-branch-parameter

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
