### PR TITLE
Bugfix: intents-operator configmap broken when combining IAM roles anywhere & ingress controllers configurations

### DIFF
--- a/intents-operator/templates/extended-config-configmap.yaml
+++ b/intents-operator/templates/extended-config-configmap.yaml
@@ -24,16 +24,14 @@ data:
         profileARN: {{ $account.intentsOperator.profileARN | required "AWS RolesAnywhere profile ARN required: account.profileARN" }}
         trustAnchorARN: {{ $account.trustAnchorARN | required "AWS RolesAnywhere trust anchor ARN required: account.trustAnchorARN" }}
         trustDomain: {{ $account.trustDomain | required "AWS RolesAnywhere trust domain required: account.trustDomain" }}
-
-
     {{- end }}
   {{- end }}
   {{- if .Values.operator.ingressControllerConfigs }}
-   ingressControllers:
-  {{- range $ingressControllerConfig := .Values.operator.ingressControllerConfigs }}
+    ingressControllers:
+    {{- range $ingressControllerConfig := .Values.operator.ingressControllerConfigs }}
       - name: {{ $ingressControllerConfig.name | quote | required "Ingress controller name required: name" }}
         namespace: {{ $ingressControllerConfig.namespace | quote | required "Ingress controller namespace required: namespace" }}
         kind: {{ $ingressControllerConfig.kind | quote | required "Ingress controller kind required: kind" }}
-  {{- end }}
+    {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description
This change fixes a bug when combining IAM roles anywhere configuration with ingress controller configuration, rendering a broken configmap for the intents operator. 

Prior to this change, the generated configmap looks as follows: 
```
---
# Source: otterize-infra/charts/otterize-kubernetes/charts/intentsOperator/templates/extended-config-configmap.yaml

apiVersion: v1
kind: ConfigMap
metadata:
  name: intents-operator-config
  namespace: infra
  labels:
    app.kubernetes.io/version: 3.0.13
  annotations:
    app.kubernetes.io/version: 3.0.13
data:
  config.yaml: |-
    aws:
      - account: "..."
        roleARN: ...
        profileARN: ...
        trustAnchorARN: ...
        trustDomain: ...
   ingressControllers:  # <--- this line is missing one space for indentation
      - name: ...
        namespace: ...
        kind: ...

---
```

This file fails on yaml-to-json conversion due to a missing whitespace in the `ingressControllers:` line. 


### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
