### PR TITLE
Bugfixes in intents-operator helm RBAC templates for AWS IAM roles anywhere

### DIFF
--- a/credentials-operator/templates/rbac-certmgr.yaml
+++ b/credentials-operator/templates/rbac-certmgr.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: creds-operator-certificaterequest-creator
-  namespace: otterize-system
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -13,7 +12,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: credentials-operator-certificaterequest
-  namespace: otterize-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,6 +19,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: credentials-operator-controller-manager
-    namespace: otterize-system
+    namespace: {{ .Release.Namespace }}
 ---
 {{- end }}

--- a/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: otterize-intents-operator-leader-election-rolebinding
+  name: otterize-intents-operator-leader-election-rolebinding-v2
   namespace: {{ .Release.Namespace }}
   labels:
     {{- with .Values.global.commonLabels }}
@@ -16,7 +16,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: intents-operator-leader-election-role
+  name: otterize-intents-operator-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: intents-operator-controller-manager

--- a/intents-operator/templates/rbac-certmgr.yaml
+++ b/intents-operator/templates/rbac-certmgr.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: intents-operator-certificaterequest-creator
-  namespace: otterize-system
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -13,7 +12,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: intents-operator-certificaterequest
-  namespace: otterize-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,5 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: intents-operator-controller-manager
-    namespace: otterize-system
+    namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
### Description
This PR includes bugfixes in the Otterize intents-operator templates for RBAC roles & role bindings, when Otterize is installed in a namespace other than otterize-system. 
Moreover, this PR fixes a wrong reference name from the `otterize-intents-operator-leader-election-rolebinding`  to `otterize-intents-operator-leader-election-role`. 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
