### PR TITLE
Re-enable auto version bump

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -8,7 +8,7 @@ jobs:
   bump-chart-versions:
     name: Bump chart versions
     runs-on: ubuntu-latest
-    if: "false"
+    if: "!contains(github.event.head_commit.message, '[nobump]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION

### Description

Re-enable version bump to auto tag and release on each helm-charts change.


### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
