### PR TITLE
Adding flag to enable secret rotation

### DIFF
--- a/credentials-operator/Chart.yaml
+++ b/credentials-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: credentials-operator
 description: credentials-operator
 type: application
-version: 2.0.16
+version: 3.0.0
 appVersion: v2.0.8
 home: https://github.com/otterize/credentials-operator
 sources:

--- a/credentials-operator/README.md
+++ b/credentials-operator/README.md
@@ -92,3 +92,4 @@
 | Key                              | Description                                                                                                                   | Default |
 |----------------------------------|-------------------------------------------------------------------------------------------------------------------------------|---------|
 | `databaseSecretRotationInterval` | Interval in which secrets created by the credentials operator will be rotated. Valid time units are "ns", "ms", "s", "m", "h" | `8h`    |
+| `enableSecretRotation`           | Whether periodic secret rotation is enabled                                                                                   | false   |

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -204,6 +204,10 @@ spec:
           - name: OTTERIZE_USE_IMAGE_NAME_FOR_SERVICE_ID_FOR_JOBS
             value: "true"
           {{- end }}
+          {{- if eq true .Values.enableSecretRotation }}
+          - name: OTTERIZE_ENABLE_SECRET_ROTATION
+            value: "true"
+          {{- end }}
           {{- if .Values.databaseSecretRotationInterval }}
           - name: OTTERIZE_DATABASE_PASSWORD_ROTATION_INTERVAL
             value: {{ .Values.databaseSecretRotationInterval | quote }}

--- a/credentials-operator/values.yaml
+++ b/credentials-operator/values.yaml
@@ -114,5 +114,6 @@ global:
 # For this resolving to be successful, the operator needs to be able to `get` all resources.
 allowGetAllResources: true
 
+enableSecretRotation: false
 # Valid time units are "ns", "ms", "s", "m", "h". Defaults to 8h if empty
 databaseSecretRotationInterval: ""

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 3.0.44
+version: 4.0.0
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:

--- a/otterize-kubernetes/README.md
+++ b/otterize-kubernetes/README.md
@@ -59,9 +59,9 @@ These parameters are used by multiple charts, and must be kept the same for the 
 
 ## Azure Integration parameters
 
-| Key                                   | Description                                 | Default  |
-|---------------------------------------|---------------------------------------------|----------|
-| `global.azure.enabled`                | Enable or disable Azure integration         | `false`  |
+| Key                                   | Description                                                            | Default  |
+|---------------------------------------|------------------------------------------------------------------------|----------|
+| `global.azure.enabled`                | Enable or disable Azure integration                                    | `false`  |
 | `global.azure.userAssignedIdentityID` | ID of the user assigned identity used by the operator to access Azure. | `(none)` |
 | `global.azure.subscriptionID`         | ID of the Azure subscription in which the AKS cluster is deployed.     | `(none)` |
 | `global.azure.resoureceGroup`         | Name of the Azure resource group in which the AKS cluster is deployed. | `(none)` |
@@ -113,7 +113,7 @@ Further information about network mapper parameters can be found [in the network
 ## Credentials operator parameters
 
 All configurable parameters of the credentials operator can be configured under the alias `credentialsOperator`.
-Further information about network mapper parameters can be found [in the network mapper's chart](https://github.com/otterize/helm-charts/tree/main/credentials-operator).
+Further information about network mapper parameters can be found [in the credentials operator's chart](https://github.com/otterize/helm-charts/tree/main/credentials-operator).
 
 ## Resource configuration
 


### PR DESCRIPTION
### Description
Adding flag to enable secret rotation, which will be off by default in the latest credentials operator release.


### Checklist
- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
