### PR TITLE
Fix validation webhook paths for api version `v1beta1`

### DIFF
--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -128,7 +128,7 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-k8s-otterize-com-v1-mysqlserverconfig
+      path: /validate-k8s-otterize-com-v1beta1-mysqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
   name: mysqlserverconfigv1.kb.io
@@ -191,7 +191,7 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-k8s-otterize-com-v1-postgresqlserverconfig
+      path: /validate-k8s-otterize-com-v1beta1-postgresqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
   name: postgresqlserverconfigv1.kb.io
@@ -254,7 +254,7 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-k8s-otterize-com-v1-protectedservice
+      path: /validate-k8s-otterize-com-v1beta1-protectedservice
   failurePolicy: Fail
   matchPolicy: Exact
   name: protectedservicev1.kb.io


### PR DESCRIPTION

### Description

The validation webhook should use the explicit version name


### References

https://github.com/otterize/intents-operator/pull/472

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
