### PR TITLE
Add support for making AWS ALB ingress controllers exempt from ingress controller restrictions

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -145,7 +145,7 @@ spec:
           {{ end }}
           - name: OTTERIZE_ENABLE_GCP_IAM_POLICY
             value: {{ .Values.global.gcp.enabled | quote }}
-          - name: OTTERIZE_INGRESS_CONTROLLERS_EXEMPT_ALB=true
+          - name: OTTERIZE_INGRESS_CONTROLLERS_EXEMPT_ALB
             value: {{ .Values.operator.ingressControllerAWSALBExempt | quote }}
           {{- if .Values.global.telemetry.errors.stage }}
           - name: OTTERIZE_TELEMETRY_ERRORS_STAGE

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -145,6 +145,8 @@ spec:
           {{ end }}
           - name: OTTERIZE_ENABLE_GCP_IAM_POLICY
             value: {{ .Values.global.gcp.enabled | quote }}
+          - name: OTTERIZE_INGRESS_CONTROLLERS_EXEMPT_ALB=true
+            value: {{ .Values.operator.ingressControllerAWSALBExempt | quote }}
           {{- if .Values.global.telemetry.errors.stage }}
           - name: OTTERIZE_TELEMETRY_ERRORS_STAGE
             value: {{ .Values.global.telemetry.errors.stage | quote }}

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -51,6 +51,7 @@ operator:
   enableIstioPolicyCreation: true
   enableDatabasePolicyCreation: true
   enableEgressNetworkPolicyCreation: false
+  ingressControllerAWSALBExempt: false
   extraEnvVars:
 
   resources: { }


### PR DESCRIPTION
This PR adds configuration for https://github.com/otterize/intents-operator/pull/476.