### PR TITLE
Rollback network-mapper to version v2.0.7

### DIFF
--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-mapper
 type: application
 version: 2.0.20
-appVersion: v2.0.8
+appVersion: v2.0.7
 home: https://github.com/otterize/network-mapper
 sources:
   - https://github.com/otterize/network-mapper


### PR DESCRIPTION
### Description
Rollback [network-mapper](https://github.com/otterize/network-mapper) to version v2.0.7 due to issues detected in v2.0.8. 