### PR TITLE
Support sniffer extended procfs resolution

### DIFF
--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -110,6 +110,10 @@ spec:
           - name: OTTERIZE_CLIENT_ID
             value: "{{ .Values.global.otterizeCloud.credentials.clientId }}"
           {{- end }}
+          {{- if eq true .Values.sniffer.useExtendedProcfsResolution }}
+          - name: OTTERIZE_USE_EXTENDED_PROCFS_RESOLUTION
+            value: "true"
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -72,6 +72,7 @@ sniffer:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+  useExtendedProcfsResolution: false
 
 kafkawatcher:
   enable: false # enable/disable entire installation of the kafka-watcher


### PR DESCRIPTION
### Description

Following changes in the network-mapper. Expose new chart value to enable extended procfs resolution feature.


### References

https://github.com/otterize/network-mapper/pull/244

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
