### PR TITLE
Fix CI issue with testing MySQL & PostgreSQL integration on forks - add missing permissions to test workflows

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -105,6 +105,10 @@ jobs:
           helm install otterize ./otterize-kubernetes -n otterize-system --wait --create-namespace $OPERATOR_FLAGS $TELEMETRY_FLAG
 
   test-postgresql-integration:
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -196,6 +200,10 @@ jobs:
         if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
 
   test-mysql-integration:
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description
This fixes `Error: Resource not accessible by integration` in the e2e-test workflows for MySQL & PostgreSQL, when running on forks, such as here: https://github.com/otterize/helm-charts/pull/253 

### References
https://github.com/dorny/test-reporter/issues/149
https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
