### PR TITLE
Allow node agent to access the host network

### DIFF
--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -104,6 +104,9 @@ spec:
           - name: OTTERIZE_PII_DETECTOR_API_URL
             value: http://{{ template "otterize.piidetector.fullName" . }}:5000/
 
+          - name: OTTERIZE_HOST_PROC_DIR
+            value: /host/proc
+
         volumeMounts:
           - name: host-proc
             mountPath: /host/proc
@@ -120,6 +123,9 @@ spec:
 
         securityContext:
           privileged: true
+
+      hostNetwork: true # use the host network for tracing network traffic
+      dnsPolicy: ClusterFirstWithHostNet # resolve kubernetes service names
 
       volumes:
         - hostPath:


### PR DESCRIPTION
### Description

Allow the node agent to access the host network in order to enable traffic control tracing 
