### PR TITLE
Remove default image tag for node agent

### DIFF
--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
      {{- end }}      
       containers:
       - name: {{ template "otterize.nodeagent.fullName" . }}
-        image: "{{ .Values.nodeagent.repository }}/{{ .Values.nodeagent.image }}:{{ default $.Chart.AppVersion .Values.nodeagent.tag }}"
+        image: "{{ .Values.nodeagent.repository }}/{{ .Values.nodeagent.image }}:{{ .Values.nodeagent.tag }}"
         {{ if .Values.nodeagent.pullPolicy }}
         imagePullPolicy: {{ .Values.nodeagent.pullPolicy }}
         {{ end }}

--- a/network-mapper/templates/pii-detector-deployment.yaml
+++ b/network-mapper/templates/pii-detector-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: {{ template "otterize.piidetector.fullName" . }}
       containers:
         - name: piidetector
-          image: "{{ .Values.piidetector.repository }}/{{ .Values.piidetector.image }}:{{ default $.Chart.AppVersion .Values.piidetector.tag }}"
+          image: "{{ .Values.piidetector.repository }}/{{ .Values.piidetector.image }}:{{ .Values.piidetector.tag }}"
           {{ if .Values.piidetector.pullPolicy }}
           imagePullPolicy: {{ .Values.piidetector.pullPolicy }}
           {{ end }}


### PR DESCRIPTION
### Description

Remove default image tag for node agent because the agent tag and the detector are stand-alone builds
