### PR TITLE
Pass azure configuration to node-agent

### DIFF
--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -104,8 +104,20 @@ spec:
           - name: OTTERIZE_PII_DETECTOR_API_URL
             value: http://{{ template "otterize.piidetector.fullName" . }}:5000/
 
+          - name: OTTERIZE_MAPPER_API_URL
+            value: http://{{ template "otterize.mapper.fullName" . }}:9090
+
           - name: OTTERIZE_HOST_PROC_DIR
             value: /host/proc
+
+          {{ if .Values.global.azure.enabled }}
+          - name: OTTERIZE_AZURE_VISIBILITY_ENABLED
+            value: "true"
+          - name: OTTERIZE_AZURE_SUBSCRIPTION_ID
+            value: {{ required "value global.azure.subscriptionID is missing" .Values.global.azure.subscriptionID | quote }}
+          - name: OTTERIZE_AZURE_RESOURCE_GROUP
+            value: {{ required "value global.azure.resourceGroup is missing" .Values.global.azure.resourceGroup | quote }}
+          {{ end }}
 
         volumeMounts:
           - name: host-proc

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -188,3 +188,8 @@ global:
       stage:
       endpointAddress:
       networkMapperApiKey: d86195588a41fa03aa6711993bb1c765
+
+  azure:
+    enabled: false
+    subscriptionID:
+    resourceGroup:


### PR DESCRIPTION
### Description

Pass azure subscription id & resource group to node-agent daemon-set

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
