### PR TITLE
Fix a bug where the intents-operator did not restart even though its `configmap` has changed

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -12,7 +12,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/version: {{ .Chart.Version }}
-    checksum/config: {{ include (print $.Template.BasePath "/extended-config-configmap.yaml") . | sha256sum }}
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -25,6 +24,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/service-name: intents-operator
+        checksum/config: {{ include (print $.Template.BasePath "/extended-config-configmap.yaml") . | sha256sum }}
         {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.certificateProvider) }}
         credentials-operator.otterize.com/tls-secret-name: intents-operator-spire-tls-controller-manager
         {{- end }}


### PR DESCRIPTION
### Description

Fix a bug where the intents-operator did not restart even though its configmap has changed. It happened because the checksum label was placed on `Deployment.Metatdata` instead of `Deployment.Spec.template.metadata`

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
