### PR TITLE
Adding support for client id in user secret for credentials

### DIFF
--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -141,7 +141,13 @@ spec:
           - name: OTTERIZE_API_ADDRESS
             value: "{{ .Values.global.otterizeCloud.apiAddress }}"
           {{ end }}
-          {{ if .Values.global.otterizeCloud.credentials.clientId }}
+          {{ if (and .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey) }}
+          - name: OTTERIZE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName }}"
+                key: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey }}"
+          {{ else if .Values.global.otterizeCloud.credentials.clientId }}
           - name: OTTERIZE_CLIENT_ID
             value: "{{ .Values.global.otterizeCloud.credentials.clientId }}"
           {{ end }}

--- a/credentials-operator/values.yaml
+++ b/credentials-operator/values.yaml
@@ -103,6 +103,8 @@ global:
       clientSecretKeyRef:
         secretName:
         secretKey:
+        clientIdKey:  # (optional) specify client ID as additional key in the same secret
+
     # (optional) The name of a secret containing a single `CA.pem` file for an extra root CA used to connect to Otterize Cloud.
     # The secret should be placed in the same namespace as the Otterize deployment
     apiExtraCAPEMSecret:

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -117,7 +117,13 @@ spec:
           - name: OTTERIZE_API_ADDRESS
             value: "{{ .Values.global.otterizeCloud.apiAddress }}"
           {{ end }}
-          {{ if .Values.global.otterizeCloud.credentials.clientId }}
+          {{ if (and .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey) }}
+          - name: OTTERIZE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName }}"
+                key: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey }}"
+          {{ else if .Values.global.otterizeCloud.credentials.clientId }}
           - name: OTTERIZE_CLIENT_ID
             value: "{{ .Values.global.otterizeCloud.credentials.clientId }}"
           {{ end }}

--- a/intents-operator/values.yaml
+++ b/intents-operator/values.yaml
@@ -160,6 +160,7 @@ global:
       clientSecretKeyRef:
         secretName:
         secretKey:
+        clientIdKey:  # (optional) specify client ID as additional key in the same secret
     # (optional) The name of a secret containing a single `CA.pem` file for an extra root CA used to connect to Otterize Cloud.
     # The secret should be placed in the same namespace as the Otterize deployment
     apiExtraCAPEMSecret:

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -97,10 +97,16 @@ spec:
             - name: OTTERIZE_SERVICE_NAME_OVERRIDE_ANNOTATION
               value: {{ .Values.global.serviceNameOverrideAnnotationName | quote }}
             {{ end }}
-            {{ if .Values.global.otterizeCloud.credentials.clientId }}
+          {{ if (and .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey) }}
+            - name: OTTERIZE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName }}"
+                  key: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey }}"
+          {{ else if .Values.global.otterizeCloud.credentials.clientId }}
             - name: OTTERIZE_CLIENT_ID
               value: "{{ .Values.global.otterizeCloud.credentials.clientId }}"
-            {{ end }}
+          {{ end }}
           {{ if (and .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretKey) }}
             - name: OTTERIZE_CLIENT_SECRET
               valueFrom:

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -185,6 +185,7 @@ global:
       clientSecretKeyRef:
         secretName:
         secretKey:
+        clientIdKey:  # (optional) specify client ID as additional key in the same secret
     # (optional) The name of a secret containing a single `CA.pem` file for an extra root CA used to connect to Otterize Cloud.
     # The secret should be placed in the same namespace as the Otterize deployment
     apiExtraCAPEMSecret:


### PR DESCRIPTION
### Description
Users can now specify a key from a secret containing the client ID for templating deployments for the credentials-operator/intents-operator/network mapper 