### PR TITLE
fix(spire): duplicate app.kubernetes.io/version labels on some resources

### DIFF
--- a/spire/templates/_helpers.tpl
+++ b/spire/templates/_helpers.tpl
@@ -76,9 +76,6 @@ Common agent labels
 {{- define "spire.agent.labels" -}}
 helm.sh/chart: {{ include "spire.chart" . }}
 {{ include "spire.agent.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
### Description

A small fix for removing duplicate app.kubernetes.io/version labels on some resources. The duplicate labels lead to invalid yaml files. Helm seems to ignore it but if you try to install the Chart with Spire activated with kustomize you get the following error:

```
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 13: mapping key "app.kubernetes.io/version" already defined at line 11
```
