### PR TITLE
Sort permissions in intents-operator-manager-clusterrole.yaml to match with the output of the generate command

### DIFF
--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -254,7 +254,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - security.istio.io
+  - policy.linkerd.io
   resources:
   - authorizationpolicies
   verbs:
@@ -267,70 +267,70 @@ rules:
   - update
   - watch
 - apiGroups:
-    - policy.linkerd.io
+  - policy.linkerd.io
   resources:
-    - authorizationpolicies
+  - httproutes
   verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - policy.linkerd.io
+  - policy.linkerd.io
   resources:
-    - meshtlsauthentications
+  - meshtlsauthentications
   verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - policy.linkerd.io
+  - policy.linkerd.io
   resources:
-    - networkauthentications
+  - networkauthentications
   verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - policy.linkerd.io
+  - policy.linkerd.io
   resources:
-    - servers
+  - servers
   verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - policy.linkerd.io
+  - security.istio.io
   resources:
-    - httproutes
+  - authorizationpolicies
   verbs:
-    - create
-    - delete
-    - deletecollection
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{ if or (and (eq .Values.global.allowGetAllResources nil) .Values.allowGetAllResources) .Values.global.allowGetAllResources}}
 - apiGroups:
     - '*'


### PR DESCRIPTION
### Description
Sort permissions in intents-operator-manager-clusterrole.yaml to match with the output of the generate command.

### References

https://github.com/otterize/intents-operator/pull/544

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
