### PR TITLE
Fix support for providing client id in user secret in node agent

### DIFF
--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -87,10 +87,18 @@ spec:
           - name: OTTERIZE_API_ADDRESS
             value: "{{ .Values.global.otterizeCloud.apiAddress }}"
           {{ end }}
-          {{ if .Values.global.otterizeCloud.credentials.clientId }}
+
+          {{ if (and .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey) }}
+          - name: OTTERIZE_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName }}"
+                key: "{{ .Values.global.otterizeCloud.credentials.clientSecretKeyRef.clientIdKey }}"
+          {{ else if .Values.global.otterizeCloud.credentials.clientId }}
           - name: OTTERIZE_CLIENT_ID
             value: "{{ .Values.global.otterizeCloud.credentials.clientId }}"
           {{ end }}
+
           {{ if (and .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretName .Values.global.otterizeCloud.credentials.clientSecretKeyRef.secretKey) }}
           - name: OTTERIZE_CLIENT_SECRET
             valueFrom:


### PR DESCRIPTION
### Description

Aligns node-agent with changes made to other components, so that the client id can be passed from a stored secret.


### References

https://github.com/otterize/helm-charts/pull/269

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
