### PR TITLE
Adding sniffer readiness & liveness probes port to values.yaml. Added linkerd to mapper excluded namespaces 

### DIFF
--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -121,13 +121,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 9090
+            port: {{ .Values.sniffer.healthProbesPort }}
           initialDelaySeconds: 30
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 9090
+            port: {{ .Values.sniffer.healthProbesPort }}
           initialDelaySeconds: 30
           periodSeconds: 20
         {{- if .Values.sniffer.containerSecurityContext }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -106,6 +106,10 @@ spec:
           - name: OTTERIZE_TELEMETRY_ERRORS_ADDRESS
             value: {{ .Values.global.telemetry.errors.endpointAddress | quote }}
           {{- end }}
+          {{- if .Values.sniffer.healthProbesPort }}
+          - name: OTTERIZE_HEALTH_PROBES_PORT
+            value: {{ .Values.sniffer.healthProbesPort | quote }}
+          {{- end }}
           {{- if .Values.global.telemetry.errors.networkMapperApiKey }}
           - name: OTTERIZE_TELEMETRY_ERRORS_API_KEY
             value: {{ .Values.global.telemetry.errors.networkMapperApiKey | quote }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -29,6 +29,7 @@ mapper:
   extraEnvVars:
   excludeNamespaces:
     - 'istio-system'
+    - 'linkerd'
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -94,6 +95,7 @@ sniffer:
   #   cpu: 100m
   #   memory: 128Mi
   useExtendedProcfsResolution: false
+  healthProbesPort: 57921
 kafkawatcher:
   enable: false # enable/disable entire installation of the kafka-watcher
   repository: otterize


### PR DESCRIPTION
### Description
Adding sniffer readiness & liveness probes port to values.yaml. Added linkerd to mapper excluded namespaces .
Solving network mapper issue [260](https://github.com/otterize/network-mapper/issues/260)
