### PR TITLE
Remove unused Azure visibility environment variables from node-agent template

### DIFF
--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -122,15 +122,6 @@ spec:
           - name: OTTERIZE_HOST_PROC_DIR
             value: /host/proc
 
-          {{ if .Values.global.azure.enabled }}
-          - name: OTTERIZE_AZURE_VISIBILITY_ENABLED
-            value: "true"
-          - name: OTTERIZE_AZURE_SUBSCRIPTION_ID
-            value: {{ required "value global.azure.subscriptionID is missing" .Values.global.azure.subscriptionID | quote }}
-          - name: OTTERIZE_AZURE_RESOURCE_GROUP
-            value: {{ required "value global.azure.resourceGroup is missing" .Values.global.azure.resourceGroup | quote }}
-          {{ end }}
-
         volumeMounts:
           - name: host-proc
             mountPath: /host/proc


### PR DESCRIPTION
### Description
Removes previously used environment variables from node agent DaemonSet template.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
