### PR TITLE
Support new API version for ClientIntents: v2beta1

### DIFF
--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -107,6 +107,27 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v2beta1-clientintents
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: clientintentsv2beta1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clientintents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /validate-k8s-otterize-com-v1alpha3-mysqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
@@ -170,6 +191,27 @@ webhooks:
     service:
       name: intents-operator-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v2beta1-mysqlserverconfig
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: mysqlserverconfigv2beta1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - mysqlserverconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /validate-k8s-otterize-com-v1alpha3-postgresqlserverconfig
   failurePolicy: Fail
   matchPolicy: Exact
@@ -221,6 +263,27 @@ webhooks:
     - k8s.otterize.com
     apiVersions:
     - v2alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - postgresqlserverconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v2beta1-postgresqlserverconfig
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: postgresqlserverconfigv2beta1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2beta1
     operations:
     - CREATE
     - UPDATE
@@ -305,6 +368,27 @@ webhooks:
     - k8s.otterize.com
     apiVersions:
     - v2alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - protectedservice
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: intents-operator-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-k8s-otterize-com-v2beta1-protectedservice
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: protectedservicev2beta1.kb.io
+  rules:
+  - apiGroups:
+    - k8s.otterize.com
+    apiVersions:
+    - v2beta1
     operations:
     - CREATE
     - UPDATE


### PR DESCRIPTION
### Description
We have revamped the format for ClientIntents to make them easier to understand and make it possible to generate more restrictive policies by default. [Read more on the docs >>](https://docs.otterize.com/reference/ClientIntents%20CRD/migrateToV2)

The two primary changes is that the word `service` is no longer used, except to mean a Kubernetes Service; before, it could mean an Otterize Service or a Kubernetes Service, which was confusing. Instead, we now use `workload` . `calls` have also been renamed `targets` , and many smaller changes to the structure to improve

What happens to your existing ClientIntents? Don’t worry, the change is backwards compatible, and nothing changes unless you explicitly upgrade. If you’re a customer, we’ll reach out to explain and plan together. If you’re using the open source, upgrading to the next **major** version of the `otterize-kubernetes` Helm chart, `vX.X.X` will make ClientIntents v2 the default. You can still continue applying ClientIntents with apiVersion `v1alpha3`, and they will be converted by the Intents Operator to `v2beta1`. 

### References

https://github.com/otterize/intents-operator/pull/552
https://github.com/otterize/credentials-operator/pull/179
https://github.com/otterize/network-mapper/pull/267
https://github.com/otterize/helm-charts/pull/278

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
