### PR TITLE
Support new API version for ClientIntents: v2beta1 - bump chart version

### DIFF
--- a/credentials-operator/Chart.yaml
+++ b/credentials-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: credentials-operator
 description: credentials-operator
 type: application
-version: 3.0.23
+version: 4.0.0
 appVersion: v4.0.0
 home: https://github.com/otterize/credentials-operator
 sources:

--- a/intents-operator/Chart.yaml
+++ b/intents-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: intents-operator
 description: Otterize intents operator
 type: application
-version: 3.0.70
+version: 4.0.0
 appVersion: v3.0.0
 home: https://github.com/otterize/intents-operator
 sources:

--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-mapper
 type: application
-version: 2.0.59
+version: 3.0.0
 appVersion: v3.0.0
 home: https://github.com/otterize/network-mapper
 sources:

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -3,7 +3,7 @@ name: otterize-kubernetes
 description: |
   This chart contains the Otterize credentials-operator, SPIRE (server+agent), the Otterize intents operator, and the Otterize network mapper.
 type: application
-version: 4.0.124
+version: 5.0.0
 home: https://github.com/otterize/helm-charts
 kubeVersion: ">=1.19.0-0"
 dependencies:


### PR DESCRIPTION
### Description
Bump major chart version on intents-operator, credentials-operator, network-mapper and otterize-kubernetes, in preparation for releasing support for ClientIntente v2. 

To learn more, [see the matching release in otterize/intents-operator](https://github.com/otterize/intents-operator/releases/tag/v3.0.0).


### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
