### PR TITLE
Added support for reusing the webhook TLS certificate across different deployments to prevent cases where operator takes too long to start up

### DIFF
--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -15,6 +15,11 @@ metadata:
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   replicas: 1
   selector:
     matchLabels:

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -56,6 +56,17 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resourceNames:
+  - intents-operator-webhook-cert
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
   resources:
   - services
   verbs:

--- a/intents-operator/templates/intents-operator-webhook-secret.yaml
+++ b/intents-operator/templates/intents-operator-webhook-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+type: Opaque
+kind: Secret
+metadata:
+  name: intents-operator-webhook-cert
+  labels:
+    {{- with .Values.global.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+  annotations:
+    {{- with .Values.global.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+data:
+  tls.crt: {{ "placeholder" | b64enc | quote }}
+  tls.key: {{ "placeholder" | b64enc | quote }}


### PR DESCRIPTION
### Description

Accompanying PR to https://github.com/otterize/intents-operator/compare/orisho/intents_operator_shared_webhook_secret?expand=1
