### PR TITLE
Added support for reusing the webhook TLS certificate across different deployments to prevent cases where credentials operator takes too long to start up

### DIFF
--- a/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
@@ -59,6 +59,17 @@ rules:
       - watch
   - apiGroups:
       - ""
+    resourceNames:
+      - credentials-operator-webhook-cert
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
     resources:
       - serviceaccounts
     verbs:

--- a/credentials-operator/templates/credentials-operator-webhook-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+type: Opaque
+kind: Secret
+metadata:
+  name: credentials-operator-webhook-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- with .Values.global.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+  annotations:
+    {{- with .Values.global.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/version: {{ .Chart.Version }}
+data:
+  tls.crt: {{ "placeholder" | b64enc | quote }}
+  tls.key: {{ "placeholder" | b64enc | quote }}


### PR DESCRIPTION
### Description

Accompanying PR to https://github.com/otterize/credentials-operator/pull/180
