### PR TITLE
Allow passing extra env variables to node-agent in helm

### DIFF
--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -139,6 +139,10 @@ spec:
             value: {{ .Values.nodeagent.telemetry.prometheus.port | quote }}
           {{ end }}
 
+          {{- if .Values.nodeagent.extraEnvVars -}}
+          {{- toYaml .Values.nodeagent.extraEnvVars | nindent 10 -}}
+          {{- end }}
+
         volumeMounts:
           - name: host-proc
             mountPath: /host/proc

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -61,6 +61,7 @@ nodeagent:
     prometheus:
       enable: false
       port: 9090
+  extraEnvVars:
 piidetector:
   repository: otterize
   image: piidetector


### PR DESCRIPTION
### Description

Allow setting custom environment variables to node-agent. Useful for setting linux, go, or internal options not exposed via helm.


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
