### PR TITLE
Report network policies to the cloud for better insights on unused policies and blocked traffic

### DIFF
--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -29,6 +29,15 @@ rules:
     - get
     - list
   - apiGroups:
+      - networking.k8s.io
+    resources:
+    # used for network policies reporting
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ''
     resources:
       - 'endpoints'


### PR DESCRIPTION


### Description

Report network policies to the cloud for better insights on unused policies and blocked traffic


### References

https://github.com/otterize/network-mapper/pull/285/files

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
