### PR TITLE
adds support for nodeSelector in network-mapper chart

### DIFF
--- a/network-mapper/README.md
+++ b/network-mapper/README.md
@@ -13,6 +13,7 @@
 | `mapper.pullSecrets`              | Mapper pull secrets.                                                                            | `(none)`                                                           |
 | `mapper.resources`                | Resources override.                                                                             | `(none)`                                                           |
 | `mapper.affinity`                 | Pod affinity.                                                                                   | `{}`                                                               |
+| `mapper.nodeSelector`             | Node selector for the mapper.                                                                   | `{}`                                                               |
 | `mapper.tolerations`              | Pod tolerations.                                                                                | `[]`                                                               |
 | `mapper.uploadIntervalSeconds`    | Interval for uploading data to cloud                                                            | `60`                                                               |
 | `mapper.excludeNamespaces`        | Namespaces excluded from reporting                                                              | `[istio-system]`                                                   |
@@ -45,6 +46,7 @@
 | `sniffer.pullSecrets`              | Sniffer pull secrets.                | `(none)`                                                           |
 | `sniffer.resources`                | Resources override.                  | `(none)`                                                           |
 | `sniffer.affinity`                 | Sniffer's pod affinity.              | `{}`                                                               |
+| `sniffer.nodeSelector`             | Sniffer's pod node selector.         | `{}`                                                               |
 | `sniffer.tolerations`              | Sniffer's pod tolerations.           | `[]`                                                               |
 | `sniffer.priorityClassName`        | Set priorityClassName.               | `(none)`                                                           |
 
@@ -61,8 +63,9 @@
 | `kafkawatcher.pullPolicy`               | Kafka watcher pull policy.                                  | `(none)`                                                           |
 | `kafkawatcher.pullSecrets`              | Kafka watcher pull secrets.                                 | `(none)`                                                           |
 | `kafkawatcher.resources`                | Resources override.                                         | `(none)`                                                           |
-| `kafkawatcher.affinity`                 | Pod affinity.                                          | `{}`                                                               |
-| `kafkawatcher.tolerations`              | Pod tolerations.                                       | `[]`                                                               |
+| `kafkawatcher.affinity`                 | Pod affinity.                                               | `{}`                                                               |
+| `kafkawatcher.nodeSelector`             | Node selector for the Kafka watcher.                        | `{}`                                                               |
+| `kafkawatcher.tolerations`              | Pod tolerations.                                            | `[]`                                                               |
 | `kafkawatcher.kafkaServers`             | Kafka servers to watch, specified as `pod.namespace` items. | `(none)`                                                           |
 
 ## IAMLive parameters

--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -174,6 +174,9 @@ spec:
       hostNetwork: true # use the host network for tracing network traffic
       dnsPolicy: ClusterFirstWithHostNet # resolve kubernetes service names
 
+      nodeSelector:
+        {{- toYaml .Values.nodeagent.nodeSelector | nindent 8 }}
+
       volumes:
         - name: host-proc
           hostPath:

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -143,6 +143,8 @@ spec:
               name: component-config
               readOnly: true
       serviceAccountName: {{ template "otterize.kafkawatcher.fullName" . }}
+      nodeSelector:
+        {{- toYaml .Values.kafkawatcher.nodeSelector | nindent 8 }}
       volumes:
         - name: component-config
           configMap:

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -219,6 +219,8 @@ spec:
             {{- toYaml .Values.mapper.containerSecurityContext | nindent 12 }}
           {{- end }}
       serviceAccountName: {{ template "otterize.mapper.fullName" . }}
+      nodeSelector:
+        {{- toYaml .Values.mapper.nodeSelector | nindent 8 }}
       volumes:
         {{ if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
         - name: api-extra-ca-pem

--- a/network-mapper/templates/pii-detector-deployment.yaml
+++ b/network-mapper/templates/pii-detector-deployment.yaml
@@ -67,4 +67,6 @@ spec:
               port: 5000
             initialDelaySeconds: 30
             periodSeconds: 10
+      nodeSelector:
+        {{- toYaml .Values.piidetector.nodeSelector | nindent 8 }}
 {{ end }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -149,6 +149,8 @@ spec:
             name: component-config
             readOnly: true
       hostNetwork: true
+      nodeSelector:
+        {{- toYaml .Values.sniffer.nodeSelector | nindent 8 }}
       dnsPolicy: ClusterFirstWithHostNet
       volumes:
         - hostPath:

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -162,7 +162,6 @@ iamlive:
         - "ALL"
   pullSecrets:
   affinity: {}
-  nodeSelector: {}
   tolerations: []
   resources: {} # see comment under mapper.resources
 visibilitydns:

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -27,6 +27,7 @@ mapper:
   pullSecrets:
   resources: {}
   affinity: {}
+  nodeSelector: {}
   tolerations: []
   extraEnvVars:
   excludeNamespaces:
@@ -49,6 +50,7 @@ nodeagent:
   tag: v0.0.24
   pullPolicy:
   affinity: {}
+  nodeSelector: {}
   tolerations: []
   resources: {}
   podSecurityContext:
@@ -68,6 +70,7 @@ piidetector:
   tag: v0.0.24
   pullPolicy:
   affinity: {}
+  nodeSelector: {}
   tolerations: []
   resources: {}
 sniffer:
@@ -87,6 +90,7 @@ sniffer:
         - NET_RAW
   pullSecrets:
   affinity: {}
+  nodeSelector: {}
   tolerations: []
   #The options to add tolerations
   # tolerations:
@@ -120,6 +124,7 @@ kafkawatcher:
         - "ALL"
   pullSecrets:
   affinity: {}
+  nodeSelector: {}
   tolerations: []
   resources: {}
   # Kafka servers to watch, specified as `pod.namespace` items.
@@ -157,6 +162,7 @@ iamlive:
         - "ALL"
   pullSecrets:
   affinity: {}
+  nodeSelector: {}
   tolerations: []
   resources: {} # see comment under mapper.resources
 visibilitydns:


### PR DESCRIPTION
### Description

This PR adds support for setting `nodeSelector` in Deployments/DaemonSet in `network-mapper` chart.

Except for `iamlive`, as I'm a bit confused about its purpose.