### PR TITLE
Support resolving TCP destination by hostname & IP address for control plane by default, and all workloads if the new flag is set to false.

### DIFF
--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -191,6 +191,10 @@ spec:
             - name: OTTERIZE_USE_IMAGE_NAME_FOR_SERVICE_ID_FOR_JOBS
               value: "true"
             {{- end }}
+            {{- if eq false .Values.mapper.resolveTCPDestByIpOnlyForControlPlane }}
+              name: OTTERIZE_TCP_DEST_RESOLVE_ONLY_CONTROL_PLANE_BY_IP
+              value: "false"
+            {{- end }}
           volumeMounts:
             {{- if .Values.global.otterizeCloud.apiExtraCAPEMSecret }}
             - mountPath: {{ template "otterize.operator.apiExtraCAPath" }}

--- a/network-mapper/values.yaml
+++ b/network-mapper/values.yaml
@@ -43,6 +43,7 @@ mapper:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  resolveTCPDestByIpOnlyForControlPlane: true
 nodeagent:
   enable: false
   repository: otterize


### PR DESCRIPTION
### Description

We introduces a bugfix to the network mapper, that has an impact on the way we resolve the TCP data the sniffer detects.
We still don't know what would be the impact of this fix (might detect a lot of new traffic), so we want by default to enable this only for traffic originated from the control plane, and after we will understand and test the impact we will release the fix to all kinds of traffic.

### References

Include any links supporting this change such as a:

- [The change in network mapper](https://github.com/otterize/network-mapper/pull/291)

If there are no references, simply delete this section.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
