### PR TITLE
Add standard app.kubernetes.io labels to otterize-kubernetes deployment

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
   "MD013": false,
-  "MD033": false
+  "MD033": false,
+  "MD059": false
 }

--- a/credentials-operator/Chart.yaml
+++ b/credentials-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: credentials-operator
 description: credentials-operator
 type: application
-version: 4.0.7
+version: 4.0.8
 appVersion: v4.0.5
 home: https://github.com/otterize/credentials-operator
 sources:

--- a/credentials-operator/templates/_helpers.tpl
+++ b/credentials-operator/templates/_helpers.tpl
@@ -6,7 +6,7 @@
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
 
-{{- define "otterize.credentialsOperator.shared_labels" }}
+{{- define "otterize.credentialsOperator.shared_labels" -}}
 app.kubernetes.io/name: credentials-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -15,7 +15,7 @@ app.kubernetes.io/version: {{ .Chart.Version }}
 {{- end }}
 {{- end }}
 
-{{- define "otterize.credentialsOperator.shared_pod_labels" }}
+{{- define "otterize.credentialsOperator.shared_pod_labels" -}}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -24,15 +24,15 @@ azure.workload.identity/use: "true"
 {{ end }}
 {{- end }}
 
-{{- define "otterize.credentialsOperator.shared_annotations" }}
+{{- define "otterize.credentialsOperator.shared_annotations" -}}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "otterize.credentialsOperator.shared_pod_annotations" }}
+{{- define "otterize.credentialsOperator.shared_pod_annotations" -}}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}
-{{- end}}}
+{{- end }}

--- a/credentials-operator/templates/_helpers.tpl
+++ b/credentials-operator/templates/_helpers.tpl
@@ -6,7 +6,7 @@
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
 
-{{- define "shared_labels" }}
+{{- define "credentialsOperator.shared_labels" }}
 app.kubernetes.io/name: credentials-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -16,7 +16,7 @@ app: credentials-operator
 {{- end }}
 {{- end }}
 
-{{- define "shared_pod_labels" }}
+{{- define "credentialsOperator.shared_pod_labels" }}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -25,14 +25,14 @@ azure.workload.identity/use: "true"
 {{ end }}
 {{- end }}
 
-{{- define "shared_annotations" }}
+{{- define "credentialsOperator.shared_annotations" }}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "shared_pod_annotations" }}
+{{- define "credentialsOperator.shared_pod_annotations" }}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}

--- a/credentials-operator/templates/_helpers.tpl
+++ b/credentials-operator/templates/_helpers.tpl
@@ -6,7 +6,7 @@
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
 
-{{- define "credentialsOperator.shared_labels" }}
+{{- define "otterize.credentialsOperator.shared_labels" }}
 app.kubernetes.io/name: credentials-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -16,7 +16,7 @@ app: credentials-operator
 {{- end }}
 {{- end }}
 
-{{- define "credentialsOperator.shared_pod_labels" }}
+{{- define "otterize.credentialsOperator.shared_pod_labels" }}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -25,14 +25,14 @@ azure.workload.identity/use: "true"
 {{ end }}
 {{- end }}
 
-{{- define "credentialsOperator.shared_annotations" }}
+{{- define "otterize.credentialsOperator.shared_annotations" }}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "credentialsOperator.shared_pod_annotations" }}
+{{- define "otterize.credentialsOperator.shared_pod_annotations" }}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}

--- a/credentials-operator/templates/_helpers.tpl
+++ b/credentials-operator/templates/_helpers.tpl
@@ -5,3 +5,35 @@
 {{- define "otterize.operator.apiExtraCAPEM" -}}
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
+
+{{- define "shared_labels" }}
+app.kubernetes.io/name: credentials-operator
+app.kubernetes.io/part-of: otterize
+app.kubernetes.io/version: {{ .Chart.Version }}
+app: credentials-operator
+{{- with .Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "shared_pod_labels" }}
+{{- with .Values.global.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{ if eq true .Values.global.azure.enabled }}
+azure.workload.identity/use: "true"
+{{ end }}
+{{- end }}
+
+{{- define "shared_annotations" }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+{{- with .Values.global.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "shared_pod_annotations" }}
+{{- with .Values.global.podAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end}}}

--- a/credentials-operator/templates/_helpers.tpl
+++ b/credentials-operator/templates/_helpers.tpl
@@ -10,7 +10,6 @@
 app.kubernetes.io/name: credentials-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
-app: credentials-operator
 {{- with .Values.global.commonLabels }}
 {{ toYaml . }}
 {{- end }}

--- a/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
@@ -5,10 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-aws-mutating-webhook-configuration
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-aws-mutating-webhook
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
@@ -5,10 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-aws-mutating-webhook-configuration
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-aws-mutating-webhook
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
@@ -5,16 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-aws-mutating-webhook-configuration
   labels:
-    app.kubernetes.io/part-of: otterize
-    app.kubernetes.io/component: credentials-operator
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-aws-mutating-webhook
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
@@ -5,10 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-aws-mutating-webhook-configuration
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-aws-mutating-webhook
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
@@ -5,10 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-azure-mutating-webhook-configuration
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-azure-mutating-webhook
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
@@ -5,10 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-azure-mutating-webhook-configuration
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-azure-mutating-webhook
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
@@ -5,10 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-azure-mutating-webhook-configuration
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-azure-mutating-webhook
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
@@ -5,16 +5,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-azure-mutating-webhook-configuration
   labels:
-    app.kubernetes.io/part-of: otterize
-    app.kubernetes.io/component: credentials-operator
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-azure-mutating-webhook
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 webhooks:
   - admissionReviewVersions:
     - v1

--- a/credentials-operator/templates/credentials-operator-client-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-client-secret.yaml
@@ -5,15 +5,10 @@ kind: Secret
 metadata:
   name: credentials-operator-otterize-cloud-client-secret
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-otterize-cloud-client-secret
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/credentials-operator/templates/credentials-operator-client-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: credentials-operator-otterize-cloud-client-secret
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-otterize-cloud-client-secret
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/credentials-operator/templates/credentials-operator-client-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: credentials-operator-otterize-cloud-client-secret
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-otterize-cloud-client-secret
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/credentials-operator/templates/credentials-operator-client-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: credentials-operator-otterize-cloud-client-secret
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-otterize-cloud-client-secret
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{ include "otterize.credentialsOperator.shared_labels" . | nindent 8}}
         {{ include "otterize.credentialsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: credentials-operator-manager
+        app: credentials-operator
     spec:
       {{- if .Values.operator.podSecurityContext }}
       securityContext:

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-deployment
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,12 +16,12 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "credentialsOperator.shared_annotations" . | nindent 8 }}
+        {{ include "credentialsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
       labels:
-        {{ include "shared_labels" . | nindent 8}}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "credentialsOperator.shared_labels" . | nindent 8}}
+        {{ include "credentialsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: credentials-operator-manager
     spec:
       {{- if .Values.operator.podSecurityContext }}

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-deployment
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,12 +16,12 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.credentialsOperator.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.credentialsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
       labels:
-        {{ include "otterize.credentialsOperator.shared_labels" . | nindent 8}}
-        {{ include "otterize.credentialsOperator.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.credentialsOperator.shared_labels" . | nindent 8}}
+        {{- include "otterize.credentialsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: credentials-operator-manager
         app: credentials-operator
     spec:

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-deployment
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,12 +16,12 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "credentialsOperator.shared_annotations" . | nindent 8 }}
-        {{ include "credentialsOperator.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.credentialsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
       labels:
-        {{ include "credentialsOperator.shared_labels" . | nindent 8}}
-        {{ include "credentialsOperator.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.credentialsOperator.shared_labels" . | nindent 8}}
+        {{ include "otterize.credentialsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: credentials-operator-manager
     spec:
       {{- if .Values.operator.podSecurityContext }}

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -2,15 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: credentials-operator
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-deployment
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,26 +16,13 @@ spec:
   template:
     metadata:
       annotations:
-        {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
       labels:
-        {{- with .Values.global.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
-        app: credentials-operator
-        {{ if eq true .Values.global.azure.enabled }}
-        azure.workload.identity/use: "true"
-        {{ end }}
+        {{ include "shared_labels" . | nindent 8}}
+        {{ include "shared_pod_labels" . | nindent 8 }}
+        app.kubernetes.io/component: credentials-operator-manager
     spec:
       {{- if .Values.operator.podSecurityContext }}
       securityContext:

--- a/credentials-operator/templates/credentials-operator-leader-election-role.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-role.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4}}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: credentials-operator-leader-election-role
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/credentials-operator/templates/credentials-operator-leader-election-role.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-role.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4}}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: credentials-operator-leader-election-role
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/credentials-operator/templates/credentials-operator-leader-election-role.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-role.yaml
@@ -4,15 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4}}
+    app.kubernetes.io/component: credentials-operator-leader-election-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/credentials-operator/templates/credentials-operator-leader-election-role.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-role.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4}}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: credentials-operator-leader-election-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
@@ -4,15 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-leader-election-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-leader-election-rolebinding
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-leader-election-rolebinding
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-leader-election-rolebinding.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-credentials-operator-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-leader-election-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
@@ -4,10 +4,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-manager-role
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-role
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
@@ -4,15 +4,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-manager-role
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-manager-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
@@ -4,10 +4,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-manager-role
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-role
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrole.yaml
@@ -4,10 +4,10 @@ metadata:
   creationTimestamp: null
   name: otterize-credentials-operator-manager-role
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-manager-rolebinding
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-rolebinding
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-manager-rolebinding
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-rolebinding
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
@@ -3,15 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-manager-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-manager-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-manager-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-manager-role.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-role.yaml
@@ -4,6 +4,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-credentials-operator-manager-scc-role
+  labels:
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-manager-scc-role
+  annotations:
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -15,15 +20,10 @@ kind: RoleBinding
 metadata:
   name: otterize-credentials-operator-manager-scc-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-manager-scc-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-manager-role.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-role.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-credentials-operator-manager-scc-role
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-scc-role
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -20,10 +20,10 @@ kind: RoleBinding
 metadata:
   name: otterize-credentials-operator-manager-scc-rolebinding
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-scc-rolebinding
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-manager-role.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-role.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-credentials-operator-manager-scc-role
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-scc-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -20,10 +20,10 @@ kind: RoleBinding
 metadata:
   name: otterize-credentials-operator-manager-scc-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-scc-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-manager-role.yaml
+++ b/credentials-operator/templates/credentials-operator-manager-role.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-credentials-operator-manager-scc-role
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-scc-role
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -20,10 +20,10 @@ kind: RoleBinding
 metadata:
   name: otterize-credentials-operator-manager-scc-rolebinding
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-manager-scc-rolebinding
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-metrics-reader
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-metrics-reader
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-metrics-reader
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-metrics-reader
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
@@ -3,15 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-metrics-reader
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-metrics-reader
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-reader-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-metrics-reader
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-metrics-reader
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/credentials-operator/templates/credentials-operator-metrics-service.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-service.yaml
@@ -2,16 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app: credentials-operator
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-controller-manager-metrics-service
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:

--- a/credentials-operator/templates/credentials-operator-metrics-service.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-controller-manager-metrics-service
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:

--- a/credentials-operator/templates/credentials-operator-metrics-service.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-controller-manager-metrics-service
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:

--- a/credentials-operator/templates/credentials-operator-metrics-service.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-controller-manager-metrics-service
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-proxy-role
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-proxy-role
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-proxy-role
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-proxy-role
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-proxy-role
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-proxy-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrole.yaml
@@ -3,15 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-credentials-operator-proxy-role
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-proxy-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-proxy-rolebinding
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-proxy-rolebinding
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-proxy-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-proxy-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-proxy-rolebinding
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-proxy-rolebinding
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
+++ b/credentials-operator/templates/credentials-operator-proxy-clusterrolebinding.yaml
@@ -3,15 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-credentials-operator-proxy-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-proxy-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/credentials-operator/templates/credentials-operator-serviceaccount.yaml
+++ b/credentials-operator/templates/credentials-operator-serviceaccount.yaml
@@ -4,15 +4,10 @@ metadata:
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-controller-manager-serviceaccount
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the credentials operator." .Values.aws.roleARN }}
     {{ end }}

--- a/credentials-operator/templates/credentials-operator-serviceaccount.yaml
+++ b/credentials-operator/templates/credentials-operator-serviceaccount.yaml
@@ -4,10 +4,10 @@ metadata:
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-controller-manager-serviceaccount
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the credentials operator." .Values.aws.roleARN }}
     {{ end }}

--- a/credentials-operator/templates/credentials-operator-serviceaccount.yaml
+++ b/credentials-operator/templates/credentials-operator-serviceaccount.yaml
@@ -4,10 +4,10 @@ metadata:
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-controller-manager-serviceaccount
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the credentials operator." .Values.aws.roleARN }}
     {{ end }}

--- a/credentials-operator/templates/credentials-operator-serviceaccount.yaml
+++ b/credentials-operator/templates/credentials-operator-serviceaccount.yaml
@@ -4,10 +4,10 @@ metadata:
   name: credentials-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-controller-manager-serviceaccount
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the credentials operator." .Values.aws.roleARN }}
     {{ end }}

--- a/credentials-operator/templates/credentials-operator-webhook-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: credentials-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-cert-secret
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/credentials-operator/templates/credentials-operator-webhook-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: credentials-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-cert-secret
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/credentials-operator/templates/credentials-operator-webhook-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-secret.yaml
@@ -5,15 +5,10 @@ metadata:
   name: credentials-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-webhook-cert-secret
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/credentials-operator/templates/credentials-operator-webhook-secret.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: credentials-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-cert-secret
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/credentials-operator/templates/credentials-operator-webhook-service.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-service.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-service
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -24,10 +24,10 @@ metadata:
   name: allow-access-to-credentials-operator-webhook-and-metrics
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-network-policy
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/credentials-operator/templates/credentials-operator-webhook-service.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-service.yaml
@@ -3,16 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app: credentials-operator
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-webhook-service
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
   name: credentials-operator-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -30,15 +24,10 @@ metadata:
   name: allow-access-to-credentials-operator-webhook-and-metrics
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-webhook-network-policy
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/credentials-operator/templates/credentials-operator-webhook-service.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-service.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-service
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -24,10 +24,10 @@ metadata:
   name: allow-access-to-credentials-operator-webhook-and-metrics
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-network-policy
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/credentials-operator/templates/credentials-operator-webhook-service.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-service.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-service
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -24,10 +24,10 @@ metadata:
   name: allow-access-to-credentials-operator-webhook-and-metrics
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-network-policy
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/credentials-operator/templates/extended-config-configmap.yaml
+++ b/credentials-operator/templates/extended-config-configmap.yaml
@@ -5,15 +5,10 @@ metadata:
   name: credentials-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-config
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
     aws:

--- a/credentials-operator/templates/extended-config-configmap.yaml
+++ b/credentials-operator/templates/extended-config-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: credentials-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-config
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
     aws:

--- a/credentials-operator/templates/extended-config-configmap.yaml
+++ b/credentials-operator/templates/extended-config-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: credentials-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-config
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
     aws:

--- a/credentials-operator/templates/extended-config-configmap.yaml
+++ b/credentials-operator/templates/extended-config-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: credentials-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-config
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
     aws:

--- a/credentials-operator/templates/rbac-certmgr.yaml
+++ b/credentials-operator/templates/rbac-certmgr.yaml
@@ -4,10 +4,10 @@ kind: Role
 metadata:
   name: creds-operator-certificaterequest-creator
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-certificaterequest-creator
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -18,10 +18,10 @@ kind: RoleBinding
 metadata:
   name: credentials-operator-certificaterequest
   labels:
-    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-certificaterequest-rolebinding
   annotations:
-    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/rbac-certmgr.yaml
+++ b/credentials-operator/templates/rbac-certmgr.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: creds-operator-certificaterequest-creator
+  labels:
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-certificaterequest-creator
+  annotations:
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -12,6 +17,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: credentials-operator-certificaterequest
+  labels:
+    {{ include "credentialsOperator.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: credentials-operator-certificaterequest-rolebinding
+  annotations:
+    {{ include "credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/credentials-operator/templates/rbac-certmgr.yaml
+++ b/credentials-operator/templates/rbac-certmgr.yaml
@@ -4,10 +4,10 @@ kind: Role
 metadata:
   name: creds-operator-certificaterequest-creator
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-certificaterequest-creator
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -18,10 +18,10 @@ kind: RoleBinding
 metadata:
   name: credentials-operator-certificaterequest
   labels:
-    {{ include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-certificaterequest-rolebinding
   annotations:
-    {{ include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/Chart.yaml
+++ b/intents-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: intents-operator
 description: Otterize intents operator
 type: application
-version: 4.0.17
+version: 4.0.18
 appVersion: v3.0.12
 home: https://github.com/otterize/intents-operator
 sources:

--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -64,7 +64,7 @@
 {{- end -}}
 
 
-{{- define "intentsOperator.shared_labels" }}
+{{- define "otterize.intentsOperator.shared_labels" }}
 app.kubernetes.io/name: intents-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -74,7 +74,7 @@ app: intents-operator
 {{- end }}
 {{- end }}
 
-{{- define "intentsOperator.shared_pod_labels" }}
+{{- define "otterize.intentsOperator.shared_pod_labels" }}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -84,14 +84,14 @@ azure.workload.identity/use: "true"
 {{- end }}
 
 
-{{- define "intentsOperator.shared_annotations" }}
+{{- define "otterize.intentsOperator.shared_annotations" }}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "intentsOperator.shared_pod_annotations" }}
+{{- define "otterize.intentsOperator.shared_pod_annotations" }}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}

--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -62,3 +62,37 @@
         {{- fail (printf "Valid values for `allowExternalTraffic`: `off`, `ifBlockedByOtterize` and `always`, but you specified `%s`" .Values.operator.allowExternalTraffic) -}}
     {{- end -}}
 {{- end -}}
+
+
+{{- define "shared_labels" }}
+app.kubernetes.io/name: intents-operator
+app.kubernetes.io/part-of: otterize
+app.kubernetes.io/version: {{ .Chart.Version }}
+app: intents-operator
+{{- with .Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "shared_pod_labels" }}
+{{- with .Values.global.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{ if eq true .Values.global.azure.enabled }}
+azure.workload.identity/use: "true"
+{{ end }}
+{{- end }}
+
+
+{{- define "shared_annotations" }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+{{- with .Values.global.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "shared_pod_annotations" }}
+{{- with .Values.global.podAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end}}}

--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -64,7 +64,7 @@
 {{- end -}}
 
 
-{{- define "otterize.intentsOperator.shared_labels" }}
+{{- define "otterize.intentsOperator.shared_labels" -}}
 app.kubernetes.io/name: intents-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -73,7 +73,7 @@ app.kubernetes.io/version: {{ .Chart.Version }}
 {{- end }}
 {{- end }}
 
-{{- define "otterize.intentsOperator.shared_pod_labels" }}
+{{- define "otterize.intentsOperator.shared_pod_labels" -}}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -83,15 +83,15 @@ azure.workload.identity/use: "true"
 {{- end }}
 
 
-{{- define "otterize.intentsOperator.shared_annotations" }}
+{{- define "otterize.intentsOperator.shared_annotations" -}}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "otterize.intentsOperator.shared_pod_annotations" }}
+{{- define "otterize.intentsOperator.shared_pod_annotations" -}}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}
-{{- end}}}
+{{- end }}

--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -64,7 +64,7 @@
 {{- end -}}
 
 
-{{- define "shared_labels" }}
+{{- define "intentsOperator.shared_labels" }}
 app.kubernetes.io/name: intents-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -74,7 +74,7 @@ app: intents-operator
 {{- end }}
 {{- end }}
 
-{{- define "shared_pod_labels" }}
+{{- define "intentsOperator.shared_pod_labels" }}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
@@ -84,14 +84,14 @@ azure.workload.identity/use: "true"
 {{- end }}
 
 
-{{- define "shared_annotations" }}
+{{- define "intentsOperator.shared_annotations" }}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "shared_pod_annotations" }}
+{{- define "intentsOperator.shared_pod_annotations" }}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}

--- a/intents-operator/templates/_helpers.tpl
+++ b/intents-operator/templates/_helpers.tpl
@@ -68,7 +68,6 @@
 app.kubernetes.io/name: intents-operator
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
-app: intents-operator
 {{- with .Values.global.commonLabels }}
 {{ toYaml . }}
 {{- end }}

--- a/intents-operator/templates/extended-config-configmap.yaml
+++ b/intents-operator/templates/extended-config-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: intents-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4}}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: intents-operator-config
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
   {{- if .Values.global.aws.rolesAnywhere.enabled }}

--- a/intents-operator/templates/extended-config-configmap.yaml
+++ b/intents-operator/templates/extended-config-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: intents-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4}}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: intents-operator-config
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
   {{- if .Values.global.aws.rolesAnywhere.enabled }}

--- a/intents-operator/templates/extended-config-configmap.yaml
+++ b/intents-operator/templates/extended-config-configmap.yaml
@@ -5,15 +5,10 @@ metadata:
   name: intents-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4}}
+    app.kubernetes.io/component: intents-operator-config
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
   {{- if .Values.global.aws.rolesAnywhere.enabled }}

--- a/intents-operator/templates/extended-config-configmap.yaml
+++ b/intents-operator/templates/extended-config-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   name: intents-operator-config
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4}}
+    {{ include "intentsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: intents-operator-config
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   config.yaml: |-
   {{- if .Values.global.aws.rolesAnywhere.enabled }}

--- a/intents-operator/templates/intents-operator-client-secret.yaml
+++ b/intents-operator/templates/intents-operator-client-secret.yaml
@@ -5,15 +5,10 @@ kind: Secret
 metadata:
   name: intents-operator-otterize-cloud-client-secret
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4}}
+    app.kubernetes.io/component: intents-operator-otterize-cloud-client-secret
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/intents-operator/templates/intents-operator-client-secret.yaml
+++ b/intents-operator/templates/intents-operator-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: intents-operator-otterize-cloud-client-secret
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4}}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: intents-operator-otterize-cloud-client-secret
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/intents-operator/templates/intents-operator-client-secret.yaml
+++ b/intents-operator/templates/intents-operator-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: intents-operator-otterize-cloud-client-secret
   labels:
-    {{ include "shared_labels" . | nindent 4}}
+    {{ include "intentsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: intents-operator-otterize-cloud-client-secret
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/intents-operator/templates/intents-operator-client-secret.yaml
+++ b/intents-operator/templates/intents-operator-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: intents-operator-otterize-cloud-client-secret
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4}}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4}}
     app.kubernetes.io/component: intents-operator-otterize-cloud-client-secret
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
@@ -2,16 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app: intents-operator
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-controller-manager-metrics-service
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -29,15 +23,10 @@ metadata:
   name: allow-access-to-intents-operator-metrics-server
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-metrics-server-network-policy
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-metrics-service
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,10 +23,10 @@ metadata:
   name: allow-access-to-intents-operator-metrics-server
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-metrics-server-network-policy
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-metrics-service
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,10 +23,10 @@ metadata:
   name: allow-access-to-intents-operator-metrics-server
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-metrics-server-network-policy
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-metrics-service
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,10 +23,10 @@ metadata:
   name: allow-access-to-intents-operator-metrics-server
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-metrics-server-network-policy
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
@@ -4,15 +4,10 @@ metadata:
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-controller-manager-serviceaccount
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the intents operator." .Values.aws.roleARN }}
     {{ end }}

--- a/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
@@ -4,10 +4,10 @@ metadata:
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-serviceaccount
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the intents operator." .Values.aws.roleARN }}
     {{ end }}

--- a/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
@@ -4,10 +4,10 @@ metadata:
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-serviceaccount
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the intents operator." .Values.aws.roleARN }}
     {{ end }}

--- a/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-serviceaccount.yaml
@@ -4,10 +4,10 @@ metadata:
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-serviceaccount
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
     {{ if (and .Values.global.aws.enabled (not (.Values.global.aws.rolesAnywhere.enabled))) }}
     "eks.amazonaws.com/role-arn": {{ required "You must specify the ARN for the role of the intents operator." .Values.aws.roleARN }}
     {{ end }}

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-deployment
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,8 +21,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "intentsOperator.shared_annotations" . | nindent 8 }}
-        {{ include "intentsOperator.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator
         checksum/config: {{ include (print $.Template.BasePath "/extended-config-configmap.yaml") . | sha256sum }}
@@ -30,8 +30,8 @@ spec:
         credentials-operator.otterize.com/tls-secret-name: intents-operator-spire-tls-controller-manager
         {{- end }}
       labels:
-        {{ include "intentsOperator.shared_labels" . | nindent 8 }}
-        {{ include "intentsOperator.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-controller-manager
     spec:
     {{- if .Values.operator.podSecurityContext }}

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -2,16 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app: intents-operator
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-controller-manager-deployment
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -27,31 +21,18 @@ spec:
   template:
     metadata:
       annotations:
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator
         checksum/config: {{ include (print $.Template.BasePath "/extended-config-configmap.yaml") . | sha256sum }}
         {{ if and (.Values.operator.autoGenerateTLSUsingCredentialsOperator) (.Values.global.certificateProvider) }}
         credentials-operator.otterize.com/tls-secret-name: intents-operator-spire-tls-controller-manager
         {{- end }}
-        {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
       labels:
-        {{- with .Values.global.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app: intents-operator
-        app.kubernetes.io/version: {{ .Chart.Version }}
-        {{ if .Values.global.azure.enabled }}
-        azure.workload.identity/use: "true"
-        {{ end }}
+        {{ include "shared_labels" . | nindent 8 }}
+        {{ include "shared_pod_labels" . | nindent 8 }}
+        app.kubernetes.io/component: intents-operator-controller-manager
     spec:
     {{- if .Values.operator.podSecurityContext }}
       securityContext:

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{ include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
         {{ include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-controller-manager
+        app: intents-operator
     spec:
     {{- if .Values.operator.podSecurityContext }}
       securityContext:

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-deployment
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,8 +21,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "otterize.intentsOperator.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.intentsOperator.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator
         checksum/config: {{ include (print $.Template.BasePath "/extended-config-configmap.yaml") . | sha256sum }}
@@ -30,8 +30,8 @@ spec:
         credentials-operator.otterize.com/tls-secret-name: intents-operator-spire-tls-controller-manager
         {{- end }}
       labels:
-        {{ include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
-        {{ include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-controller-manager
         app: intents-operator
     spec:

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-deployment
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,8 +21,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "intentsOperator.shared_annotations" . | nindent 8 }}
+        {{ include "intentsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator
         checksum/config: {{ include (print $.Template.BasePath "/extended-config-configmap.yaml") . | sha256sum }}
@@ -30,8 +30,8 @@ spec:
         credentials-operator.otterize.com/tls-secret-name: intents-operator-spire-tls-controller-manager
         {{- end }}
       labels:
-        {{ include "shared_labels" . | nindent 8 }}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "intentsOperator.shared_labels" . | nindent 8 }}
+        {{ include "intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-controller-manager
     spec:
     {{- if .Values.operator.podSecurityContext }}

--- a/intents-operator/templates/intents-operator-leader-election-role.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-role.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-role
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/intents-operator/templates/intents-operator-leader-election-role.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-role.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/intents-operator/templates/intents-operator-leader-election-role.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-role.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-role
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/intents-operator/templates/intents-operator-leader-election-role.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-role.yaml
@@ -4,15 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-role
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-leader-election-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-rolebinding-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-rolebinding-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
@@ -4,15 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-rolebinding-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
+++ b/intents-operator/templates/intents-operator-leader-election-rolebinding.yaml
@@ -4,10 +4,10 @@ metadata:
   name: otterize-intents-operator-leader-election-rolebinding-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-manager-role
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-manager-role
   annotations:
-      {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+      {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-manager-role
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-manager-role
   annotations:
-      {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+      {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/intents-operator/templates/intents-operator-manager-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrole.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: otterize-intents-operator-manager-role
+  labels:
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-manager-role
+  annotations:
+      {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-manager-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-manager-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-manager-rolebinding
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-manager-rolebinding
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
@@ -3,15 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-manager-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-manager-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-manager-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-manager-rolebinding
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-manager-rolebinding
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-manager-role.yaml
+++ b/intents-operator/templates/intents-operator-manager-role.yaml
@@ -15,10 +15,10 @@ kind: RoleBinding
 metadata:
   name: otterize-intents-operator-manager-scc-rolebinding
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-manager-role.yaml
+++ b/intents-operator/templates/intents-operator-manager-role.yaml
@@ -15,10 +15,10 @@ kind: RoleBinding
 metadata:
   name: otterize-intents-operator-manager-scc-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-manager-role.yaml
+++ b/intents-operator/templates/intents-operator-manager-role.yaml
@@ -15,10 +15,10 @@ kind: RoleBinding
 metadata:
   name: otterize-intents-operator-manager-scc-rolebinding
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-manager-role.yaml
+++ b/intents-operator/templates/intents-operator-manager-role.yaml
@@ -15,15 +15,10 @@ kind: RoleBinding
 metadata:
   name: otterize-intents-operator-manager-scc-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-leader-election-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
@@ -3,15 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-metrics-reader
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-metrics-reader
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-metrics-reader
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-metrics-reader
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-metrics-reader
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-metrics-reader
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-metrics-reader-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-metrics-reader
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-metrics-reader
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics

--- a/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-proxy-role
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-proxy-role
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-proxy-role
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-proxy-role
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
@@ -3,15 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-proxy-role
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-proxy-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: otterize-intents-operator-proxy-role
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-proxy-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
@@ -3,15 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-proxy-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-proxy-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-proxy-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-proxy-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-proxy-rolebinding
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-proxy-rolebinding
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
+++ b/intents-operator/templates/intents-operator-proxy-clusterrolebinding.yaml
@@ -3,10 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: otterize-intents-operator-proxy-rolebinding
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-proxy-rolebinding
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/intents-operator/templates/intents-operator-webhook-secret.yaml
+++ b/intents-operator/templates/intents-operator-webhook-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: intents-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-cert-secret
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/intents-operator/templates/intents-operator-webhook-secret.yaml
+++ b/intents-operator/templates/intents-operator-webhook-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: intents-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-cert-secret
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/intents-operator/templates/intents-operator-webhook-secret.yaml
+++ b/intents-operator/templates/intents-operator-webhook-secret.yaml
@@ -5,15 +5,10 @@ metadata:
   name: intents-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-webhook-cert-secret
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/intents-operator/templates/intents-operator-webhook-secret.yaml
+++ b/intents-operator/templates/intents-operator-webhook-secret.yaml
@@ -5,10 +5,10 @@ metadata:
   name: intents-operator-webhook-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-cert-secret
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 data:
   tls.crt: {{ "placeholder" | b64enc | quote }}
   tls.key: {{ "placeholder" | b64enc | quote }}

--- a/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
+++ b/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-server-deployment
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-webhook-server
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,13 +21,13 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "intentsOperator.shared_annotations" . | nindent 8 }}
+        {{ include "intentsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator-webhook-server
       labels:
-        {{ include "shared_labels" . | nindent 8 }}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "intentsOperator.shared_labels" . | nindent 8 }}
+        {{ include "intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-webhook-server
     spec:
     {{- if .Values.webhookServer.podSecurityContext }}

--- a/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
+++ b/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-server-deployment
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-webhook-server
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,13 +21,13 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "intentsOperator.shared_annotations" . | nindent 8 }}
-        {{ include "intentsOperator.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator-webhook-server
       labels:
-        {{ include "intentsOperator.shared_labels" . | nindent 8 }}
-        {{ include "intentsOperator.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
+        {{ include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-webhook-server
     spec:
     {{- if .Values.webhookServer.podSecurityContext }}

--- a/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
+++ b/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-server-deployment
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-webhook-server
   namespace: {{ .Release.Namespace }}
 spec:
@@ -21,13 +21,13 @@ spec:
   template:
     metadata:
       annotations:
-        {{ include "otterize.intentsOperator.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.intentsOperator.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator-webhook-server
       labels:
-        {{ include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
-        {{ include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
+        {{- include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-webhook-server
         app: intents-operator-webhook-server
     spec:

--- a/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
+++ b/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         {{ include "otterize.intentsOperator.shared_labels" . | nindent 8 }}
         {{ include "otterize.intentsOperator.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: intents-operator-webhook-server
+        app: intents-operator-webhook-server
     spec:
     {{- if .Values.webhookServer.podSecurityContext }}
       securityContext:

--- a/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
+++ b/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
@@ -2,16 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app: intents-operator-webhook-server
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-webhook-server-deployment
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
   name: intents-operator-webhook-server
   namespace: {{ .Release.Namespace }}
 spec:
@@ -27,27 +21,14 @@ spec:
   template:
     metadata:
       annotations:
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
         kubectl.kubernetes.io/default-container: manager
         intents.otterize.com/workload-name: intents-operator-webhook-server
-        {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
       labels:
-        {{- with .Values.global.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app: intents-operator-webhook-server
-        app.kubernetes.io/version: {{ .Chart.Version }}
-        {{ if .Values.global.azure.enabled }}
-        azure.workload.identity/use: "true"
-        {{ end }}
+        {{ include "shared_labels" . | nindent 8 }}
+        {{ include "shared_pod_labels" . | nindent 8 }}
+        app.kubernetes.io/component: intents-operator-webhook-server
     spec:
     {{- if .Values.webhookServer.podSecurityContext }}
       securityContext:

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -1,20 +1,24 @@
 apiVersion: v1
 data:
-  serviceName: intents-operator-webhook-service
-  serviceNamespace: {{ .Release.Namespace }}
+  serviceName: "intents-operator-webhook-service"
+  serviceNamespace: {{ .Release.Namespace | quote }}
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: intents-operator
-    app.kubernetes.io/part-of: otterize
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-webhook-configmap
+  annotations:
+    {{ include "shared_annotations" . | nindent 4 }}
   name: otterize-webhook-configmap
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    app.kubernetes.io/component: intents-operator
-    app.kubernetes.io/part-of: otterize
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-validating-webhook-configuration
+  annotations:
+    {{ include "shared_annotations" . | nindent 4 }}
   name: otterize-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -5,20 +5,20 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-configmap
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-webhook-configmap
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-validating-webhook-configuration
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -5,20 +5,20 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-configmap
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-webhook-configmap
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-validating-webhook-configuration
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -5,20 +5,20 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-configmap
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-webhook-configmap
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-validating-webhook-configuration
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/intents-operator/templates/rbac-certmgr.yaml
+++ b/intents-operator/templates/rbac-certmgr.yaml
@@ -3,6 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: intents-operator-certificaterequest-creator
+  labels:
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-certificaterequest-creator
+  annotations:
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -12,6 +17,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: intents-operator-certificaterequest
+  labels:
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-certificaterequest-rolebinding
+  annotations:
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/rbac-certmgr.yaml
+++ b/intents-operator/templates/rbac-certmgr.yaml
@@ -4,10 +4,10 @@ kind: Role
 metadata:
   name: intents-operator-certificaterequest-creator
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-certificaterequest-creator
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -18,10 +18,10 @@ kind: RoleBinding
 metadata:
   name: intents-operator-certificaterequest
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-certificaterequest-rolebinding
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/rbac-certmgr.yaml
+++ b/intents-operator/templates/rbac-certmgr.yaml
@@ -4,10 +4,10 @@ kind: Role
 metadata:
   name: intents-operator-certificaterequest-creator
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-certificaterequest-creator
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
@@ -18,10 +18,10 @@ kind: RoleBinding
 metadata:
   name: intents-operator-certificaterequest
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-certificaterequest-rolebinding
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/intents-operator/templates/validation-webhook-service.yaml
+++ b/intents-operator/templates/validation-webhook-service.yaml
@@ -4,10 +4,10 @@ metadata:
   name: intents-operator-webhook-service
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-service
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   ports:
     - port: 443
@@ -22,10 +22,10 @@ metadata:
   name: allow-access-to-intents-operator-webhook
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-network-policy
   annotations:
-    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/intents-operator/templates/validation-webhook-service.yaml
+++ b/intents-operator/templates/validation-webhook-service.yaml
@@ -4,15 +4,10 @@ metadata:
   name: intents-operator-webhook-service
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-webhook-service
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   ports:
     - port: 443
@@ -27,15 +22,10 @@ metadata:
   name: allow-access-to-intents-operator-webhook
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: intents-operator-webhook-network-policy
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/intents-operator/templates/validation-webhook-service.yaml
+++ b/intents-operator/templates/validation-webhook-service.yaml
@@ -4,10 +4,10 @@ metadata:
   name: intents-operator-webhook-service
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-service
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   ports:
     - port: 443
@@ -22,10 +22,10 @@ metadata:
   name: allow-access-to-intents-operator-webhook
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-network-policy
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/intents-operator/templates/validation-webhook-service.yaml
+++ b/intents-operator/templates/validation-webhook-service.yaml
@@ -4,10 +4,10 @@ metadata:
   name: intents-operator-webhook-service
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-service
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   ports:
     - port: 443
@@ -22,10 +22,10 @@ metadata:
   name: allow-access-to-intents-operator-webhook
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "intentsOperator.shared_labels" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-network-policy
   annotations:
-    {{ include "intentsOperator.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/network-mapper/Chart.yaml
+++ b/network-mapper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-mapper
 type: application
-version: 3.0.37
+version: 3.0.38
 appVersion: v3.0.15
 home: https://github.com/otterize/network-mapper
 sources:

--- a/network-mapper/templates/_helpers.tpl
+++ b/network-mapper/templates/_helpers.tpl
@@ -37,7 +37,7 @@ otterize-network-mapper-component-config-map
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
 
-{{- define "shared_labels" }}
+{{- define "networkMapper.shared_labels" }}
 app.kubernetes.io/name: network-mapper
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -46,20 +46,20 @@ app.kubernetes.io/version: {{ .Chart.Version }}
 {{- end }}
 {{- end }}
 
-{{- define "shared_pod_labels" }}
+{{- define "networkMapper.shared_pod_labels" }}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "shared_annotations" }}
+{{- define "networkMapper.shared_annotations" }}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "shared_pod_annotations" }}
+{{- define "networkMapper.shared_pod_annotations" }}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}

--- a/network-mapper/templates/_helpers.tpl
+++ b/network-mapper/templates/_helpers.tpl
@@ -37,7 +37,7 @@ otterize-network-mapper-component-config-map
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
 
-{{- define "networkMapper.shared_labels" }}
+{{- define "otterize.networkMapper.shared_labels" }}
 app.kubernetes.io/name: network-mapper
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -46,20 +46,20 @@ app.kubernetes.io/version: {{ .Chart.Version }}
 {{- end }}
 {{- end }}
 
-{{- define "networkMapper.shared_pod_labels" }}
+{{- define "otterize.networkMapper.shared_pod_labels" }}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "networkMapper.shared_annotations" }}
+{{- define "otterize.networkMapper.shared_annotations" }}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "networkMapper.shared_pod_annotations" }}
+{{- define "otterize.networkMapper.shared_pod_annotations" }}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}

--- a/network-mapper/templates/_helpers.tpl
+++ b/network-mapper/templates/_helpers.tpl
@@ -37,7 +37,7 @@ otterize-network-mapper-component-config-map
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
 
-{{- define "otterize.networkMapper.shared_labels" }}
+{{- define "otterize.networkMapper.shared_labels" -}}
 app.kubernetes.io/name: network-mapper
 app.kubernetes.io/part-of: otterize
 app.kubernetes.io/version: {{ .Chart.Version }}
@@ -46,21 +46,21 @@ app.kubernetes.io/version: {{ .Chart.Version }}
 {{- end }}
 {{- end }}
 
-{{- define "otterize.networkMapper.shared_pod_labels" }}
+{{- define "otterize.networkMapper.shared_pod_labels" -}}
 {{- with .Values.global.podLabels }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "otterize.networkMapper.shared_annotations" }}
+{{- define "otterize.networkMapper.shared_annotations" -}}
 app.kubernetes.io/version: {{ .Chart.Version }}
 {{- with .Values.global.commonAnnotations }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}
 
-{{- define "otterize.networkMapper.shared_pod_annotations" }}
+{{- define "otterize.networkMapper.shared_pod_annotations" -}}
 {{- with .Values.global.podAnnotations }}
 {{ toYaml . }}
 {{- end }}
-{{- end}}}
+{{- end }}

--- a/network-mapper/templates/_helpers.tpl
+++ b/network-mapper/templates/_helpers.tpl
@@ -36,3 +36,31 @@ otterize-network-mapper-component-config-map
 {{- define "otterize.operator.apiExtraCAPEM" -}}
 {{ template "otterize.operator.apiExtraCAPath" }}/CA.pem
 {{- end -}}
+
+{{- define "shared_labels" }}
+app.kubernetes.io/name: network-mapper
+app.kubernetes.io/part-of: otterize
+app.kubernetes.io/version: {{ .Chart.Version }}
+{{- with .Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "shared_pod_labels" }}
+{{- with .Values.global.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "shared_annotations" }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+{{- with .Values.global.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "shared_pod_annotations" }}
+{{- with .Values.global.podAnnotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end}}}

--- a/network-mapper/templates/agent-clusterrole.yaml
+++ b/network-mapper/templates/agent-clusterrole.yaml
@@ -4,15 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: nodeagent-clusterrole
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - '*'

--- a/network-mapper/templates/agent-clusterrole.yaml
+++ b/network-mapper/templates/agent-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-clusterrole
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - '*'

--- a/network-mapper/templates/agent-clusterrole.yaml
+++ b/network-mapper/templates/agent-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-clusterrole
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - '*'

--- a/network-mapper/templates/agent-clusterrole.yaml
+++ b/network-mapper/templates/agent-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-clusterrole
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - '*'

--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -4,10 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-daemonset
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "shared_labels" . | nindent 8 }}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
         app: {{ template "otterize.nodeagent.fullName" . }}
         app.kubernetes.io/component: nodeagent
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.nodeagent.fullName" . }}
     {{- if .Values.nodeagent.podSecurityContext }}

--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -17,8 +17,8 @@ spec:
       labels:
         {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
         {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
-        app: {{ template "otterize.nodeagent.fullName" . }}
         app.kubernetes.io/component: nodeagent
+        app: {{ template "otterize.nodeagent.fullName" . }}
       annotations:
         {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
         {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}

--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -4,10 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-daemonset
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app: {{ template "otterize.nodeagent.fullName" . }}
         app.kubernetes.io/component: nodeagent
       annotations:
-        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.nodeagent.fullName" . }}
     {{- if .Values.nodeagent.podSecurityContext }}

--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -4,15 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: nodeagent-daemonset
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -20,22 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- with .Values.global.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{ include "shared_labels" . | nindent 8 }}
+        {{ include "shared_pod_labels" . | nindent 8 }}
         app: {{ template "otterize.nodeagent.fullName" . }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        app.kubernetes.io/component: nodeagent
       annotations:
-        {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.nodeagent.fullName" . }}
     {{- if .Values.nodeagent.podSecurityContext }}

--- a/network-mapper/templates/agent-daemonset.yaml
+++ b/network-mapper/templates/agent-daemonset.yaml
@@ -4,10 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-daemonset
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: nodeagent
         app: {{ template "otterize.nodeagent.fullName" . }}
       annotations:
-        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.nodeagent.fullName" . }}
     {{- if .Values.nodeagent.podSecurityContext }}

--- a/network-mapper/templates/agent-serviceaccount.yaml
+++ b/network-mapper/templates/agent-serviceaccount.yaml
@@ -4,20 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-serviceaccount
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-clusterrolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/network-mapper/templates/agent-serviceaccount.yaml
+++ b/network-mapper/templates/agent-serviceaccount.yaml
@@ -4,30 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: nodeagent-serviceaccount
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: nodeagent-clusterrolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/network-mapper/templates/agent-serviceaccount.yaml
+++ b/network-mapper/templates/agent-serviceaccount.yaml
@@ -4,20 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-serviceaccount
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-clusterrolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/network-mapper/templates/agent-serviceaccount.yaml
+++ b/network-mapper/templates/agent-serviceaccount.yaml
@@ -4,20 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-serviceaccount
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.nodeagent.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: nodeagent-clusterrolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/network-mapper/templates/component-config-map.yaml
+++ b/network-mapper/templates/component-config-map.yaml
@@ -4,8 +4,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "otterize.mapper.componentConfigmap" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-component-configmap
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 data: {}

--- a/network-mapper/templates/component-config-map.yaml
+++ b/network-mapper/templates/component-config-map.yaml
@@ -4,8 +4,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "otterize.mapper.componentConfigmap" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-component-configmap
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 data: {}

--- a/network-mapper/templates/component-config-map.yaml
+++ b/network-mapper/templates/component-config-map.yaml
@@ -4,13 +4,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "otterize.mapper.componentConfigmap" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-component-configmap
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data: {}

--- a/network-mapper/templates/component-config-map.yaml
+++ b/network-mapper/templates/component-config-map.yaml
@@ -4,8 +4,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "otterize.mapper.componentConfigmap" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-component-configmap
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 data: {}

--- a/network-mapper/templates/kafka-watcher-clusterrole.yaml
+++ b/network-mapper/templates/kafka-watcher-clusterrole.yaml
@@ -4,15 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafkawatcher-clusterrole
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''

--- a/network-mapper/templates/kafka-watcher-clusterrole.yaml
+++ b/network-mapper/templates/kafka-watcher-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-clusterrole
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''

--- a/network-mapper/templates/kafka-watcher-clusterrole.yaml
+++ b/network-mapper/templates/kafka-watcher-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-clusterrole
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''

--- a/network-mapper/templates/kafka-watcher-clusterrole.yaml
+++ b/network-mapper/templates/kafka-watcher-clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-clusterrole
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -4,15 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafkawatcher-deployment
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -21,22 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- with .Values.global.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{ include "shared_labels" . | nindent 8 }}
+        {{ include "shared_pod_labels" . | nindent 8 }}
         app: {{ template "otterize.kafkawatcher.fullName" . }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        app.kubernetes.io/component: kafkawatcher
       annotations:
-        {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
     spec:
       securityContext:
         {{- toYaml .Values.kafkawatcher.containerSecurityContext | nindent 10 }}

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-deployment
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -16,13 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "shared_labels" . | nindent 8 }}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
         app: {{ template "otterize.kafkawatcher.fullName" . }}
         app.kubernetes.io/component: kafkawatcher
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       securityContext:
         {{- toYaml .Values.kafkawatcher.containerSecurityContext | nindent 10 }}

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-deployment
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -16,13 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app: {{ template "otterize.kafkawatcher.fullName" . }}
         app.kubernetes.io/component: kafkawatcher
       annotations:
-        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       securityContext:
         {{- toYaml .Values.kafkawatcher.containerSecurityContext | nindent 10 }}

--- a/network-mapper/templates/kafka-watcher-deployment.yaml
+++ b/network-mapper/templates/kafka-watcher-deployment.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-deployment
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -16,13 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app: {{ template "otterize.kafkawatcher.fullName" . }}
         app.kubernetes.io/component: kafkawatcher
       annotations:
-        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       securityContext:
         {{- toYaml .Values.kafkawatcher.containerSecurityContext | nindent 10 }}

--- a/network-mapper/templates/kafka-watcher-role.yaml
+++ b/network-mapper/templates/kafka-watcher-role.yaml
@@ -4,10 +4,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -63,10 +63,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}-scc-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-scc-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/kafka-watcher-role.yaml
+++ b/network-mapper/templates/kafka-watcher-role.yaml
@@ -4,15 +4,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafkawatcher-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -68,15 +63,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}-scc-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafkawatcher-scc-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/kafka-watcher-role.yaml
+++ b/network-mapper/templates/kafka-watcher-role.yaml
@@ -4,10 +4,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-role
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -63,10 +63,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}-scc-rolebinding
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-scc-rolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/kafka-watcher-role.yaml
+++ b/network-mapper/templates/kafka-watcher-role.yaml
@@ -4,10 +4,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-role
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -63,10 +63,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}-scc-rolebinding
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-scc-rolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/kafka-watcher-serviceaccount.yaml
+++ b/network-mapper/templates/kafka-watcher-serviceaccount.yaml
@@ -4,20 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-serviceaccount
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-clusterrolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -32,10 +32,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-rolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/kafka-watcher-serviceaccount.yaml
+++ b/network-mapper/templates/kafka-watcher-serviceaccount.yaml
@@ -4,20 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-serviceaccount
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-clusterrolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -32,10 +32,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/kafka-watcher-serviceaccount.yaml
+++ b/network-mapper/templates/kafka-watcher-serviceaccount.yaml
@@ -4,30 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafkawatcher-serviceaccount
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafkawatcher-clusterrolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -42,15 +32,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: kafkawatcher-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/kafka-watcher-serviceaccount.yaml
+++ b/network-mapper/templates/kafka-watcher-serviceaccount.yaml
@@ -4,20 +4,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-serviceaccount
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-clusterrolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -32,10 +32,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.kafkawatcher.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: kafkawatcher-rolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-client-secret.yaml
+++ b/network-mapper/templates/mapper-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: mapper-otterize-cloud-client-secret
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: mapper-otterize-cloud-client-secret
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/network-mapper/templates/mapper-client-secret.yaml
+++ b/network-mapper/templates/mapper-client-secret.yaml
@@ -5,15 +5,10 @@ kind: Secret
 metadata:
   name: mapper-otterize-cloud-client-secret
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: mapper-otterize-cloud-client-secret
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/network-mapper/templates/mapper-client-secret.yaml
+++ b/network-mapper/templates/mapper-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: mapper-otterize-cloud-client-secret
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: mapper-otterize-cloud-client-secret
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/network-mapper/templates/mapper-client-secret.yaml
+++ b/network-mapper/templates/mapper-client-secret.yaml
@@ -5,10 +5,10 @@ kind: Secret
 metadata:
   name: mapper-otterize-cloud-client-secret
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: mapper-otterize-cloud-client-secret
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 data:
   otterize-cloud-client-secret: {{ .Values.global.otterizeCloud.credentials.clientSecret | b64enc | quote }}
 {{ end }}

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-clusterrole
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
     - k8s.otterize.com

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -3,15 +3,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-clusterrole
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
     - k8s.otterize.com

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-clusterrole
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
     - k8s.otterize.com

--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -3,10 +3,10 @@ kind: ClusterRole
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-clusterrole
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
     - k8s.otterize.com

--- a/network-mapper/templates/mapper-configmap.yaml
+++ b/network-mapper/templates/mapper-configmap.yaml
@@ -3,9 +3,9 @@ kind: ConfigMap
 metadata:
   name: {{ template "otterize.mapper.configMapName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-configmap
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 data: {}
 binaryData: {} # mapper will add data here on runtime

--- a/network-mapper/templates/mapper-configmap.yaml
+++ b/network-mapper/templates/mapper-configmap.yaml
@@ -3,14 +3,9 @@ kind: ConfigMap
 metadata:
   name: {{ template "otterize.mapper.configMapName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-configmap
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 data: {}
 binaryData: {} # mapper will add data here on runtime

--- a/network-mapper/templates/mapper-configmap.yaml
+++ b/network-mapper/templates/mapper-configmap.yaml
@@ -3,9 +3,9 @@ kind: ConfigMap
 metadata:
   name: {{ template "otterize.mapper.configMapName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-configmap
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 data: {}
 binaryData: {} # mapper will add data here on runtime

--- a/network-mapper/templates/mapper-configmap.yaml
+++ b/network-mapper/templates/mapper-configmap.yaml
@@ -3,9 +3,9 @@ kind: ConfigMap
 metadata:
   name: {{ template "otterize.mapper.configMapName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-configmap
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 data: {}
 binaryData: {} # mapper will add data here on runtime

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -3,15 +3,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-deployment
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -20,22 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- with .Values.global.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{ include "shared_labels" . | nindent 8 }}
+        {{ include "shared_pod_labels" . | nindent 8 }}
+        app.kubernetes.io/component: network-mapper
         app: {{ template "otterize.mapper.fullName" . }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
       annotations:
-        {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
     spec:
       {{- if .Values.mapper.podSecurityContext }}
       securityContext:

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -3,10 +3,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-deployment
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "shared_labels" . | nindent 8 }}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: network-mapper
         app: {{ template "otterize.mapper.fullName" . }}
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       {{- if .Values.mapper.podSecurityContext }}
       securityContext:

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -3,10 +3,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-deployment
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: network-mapper
         app: {{ template "otterize.mapper.fullName" . }}
       annotations:
-        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       {{- if .Values.mapper.podSecurityContext }}
       securityContext:

--- a/network-mapper/templates/mapper-deployment.yaml
+++ b/network-mapper/templates/mapper-deployment.yaml
@@ -3,10 +3,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-deployment
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: network-mapper
         app: {{ template "otterize.mapper.fullName" . }}
       annotations:
-        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       {{- if .Values.mapper.podSecurityContext }}
       securityContext:

--- a/network-mapper/templates/mapper-role.yaml
+++ b/network-mapper/templates/mapper-role.yaml
@@ -3,15 +3,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -58,15 +53,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-mapper-scc-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-scc-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-role.yaml
+++ b/network-mapper/templates/mapper-role.yaml
@@ -3,10 +3,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-role
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -43,10 +43,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-network-mapper-scc-role
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-scc-role
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -58,10 +58,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-mapper-scc-rolebinding
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-scc-rolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-role.yaml
+++ b/network-mapper/templates/mapper-role.yaml
@@ -3,10 +3,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-role
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -43,10 +43,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-network-mapper-scc-role
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-scc-role
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -58,10 +58,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-mapper-scc-rolebinding
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-scc-rolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-role.yaml
+++ b/network-mapper/templates/mapper-role.yaml
@@ -3,10 +3,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -42,6 +42,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-network-mapper-scc-role
+  labels:
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-scc-role
+  annotations:
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -53,10 +58,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-mapper-scc-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-scc-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-service.yaml
+++ b/network-mapper/templates/mapper-service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-service
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.mapper.fullName" . }}

--- a/network-mapper/templates/mapper-service.yaml
+++ b/network-mapper/templates/mapper-service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-service
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.mapper.fullName" . }}

--- a/network-mapper/templates/mapper-service.yaml
+++ b/network-mapper/templates/mapper-service.yaml
@@ -3,15 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-service
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.mapper.fullName" . }}

--- a/network-mapper/templates/mapper-service.yaml
+++ b/network-mapper/templates/mapper-service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-service
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.mapper.fullName" . }}

--- a/network-mapper/templates/mapper-serviceaccount.yaml
+++ b/network-mapper/templates/mapper-serviceaccount.yaml
@@ -3,20 +3,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-serviceaccount
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-clusterrolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -31,10 +31,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-rolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-serviceaccount.yaml
+++ b/network-mapper/templates/mapper-serviceaccount.yaml
@@ -3,20 +3,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-serviceaccount
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-clusterrolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -31,10 +31,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-serviceaccount.yaml
+++ b/network-mapper/templates/mapper-serviceaccount.yaml
@@ -3,20 +3,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-serviceaccount
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-clusterrolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -31,10 +31,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-rolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-serviceaccount.yaml
+++ b/network-mapper/templates/mapper-serviceaccount.yaml
@@ -3,30 +3,20 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-serviceaccount
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-clusterrolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -41,15 +31,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.mapper.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/mapper-webhook-service.yaml
+++ b/network-mapper/templates/mapper-webhook-service.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-webhook-service
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
   name: otterize-network-mapper-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,10 +23,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name}}-allow-webhook-access-from-all-namespaces
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-webhook-network-policy
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   ingress:
     - ports:

--- a/network-mapper/templates/mapper-webhook-service.yaml
+++ b/network-mapper/templates/mapper-webhook-service.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-webhook-service
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
   name: otterize-network-mapper-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,10 +23,10 @@ kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name}}-allow-webhook-access-from-all-namespaces
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-webhook-network-policy
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   ingress:
     - ports:

--- a/network-mapper/templates/mapper-webhook-service.yaml
+++ b/network-mapper/templates/mapper-webhook-service.yaml
@@ -3,16 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
-    app: otterize-network-mapper
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-webhook-service
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
   name: otterize-network-mapper-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:

--- a/network-mapper/templates/mapper-webhook-service.yaml
+++ b/network-mapper/templates/mapper-webhook-service.yaml
@@ -3,10 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-webhook-service
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
   name: otterize-network-mapper-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -22,6 +22,11 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name}}-allow-webhook-access-from-all-namespaces
+  labels:
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-mapper-webhook-network-policy
+  annotations:
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   ingress:
     - ports:

--- a/network-mapper/templates/pii-detector-deployment.yaml
+++ b/network-mapper/templates/pii-detector-deployment.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-deployment
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -16,13 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: pii-detector
         app: {{ template "otterize.piidetector.fullName" . }}
       annotations:
-        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.piidetector.fullName" . }}
       {{- with .Values.piidetector.tolerations }}

--- a/network-mapper/templates/pii-detector-deployment.yaml
+++ b/network-mapper/templates/pii-detector-deployment.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-deployment
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -16,13 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: pii-detector
         app: {{ template "otterize.piidetector.fullName" . }}
       annotations:
-        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.piidetector.fullName" . }}
       {{- with .Values.piidetector.tolerations }}

--- a/network-mapper/templates/pii-detector-deployment.yaml
+++ b/network-mapper/templates/pii-detector-deployment.yaml
@@ -4,10 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-deployment
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -16,13 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "shared_labels" . | nindent 8 }}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: pii-detector
         app: {{ template "otterize.piidetector.fullName" . }}
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.piidetector.fullName" . }}
       {{- with .Values.piidetector.tolerations }}

--- a/network-mapper/templates/pii-detector-deployment.yaml
+++ b/network-mapper/templates/pii-detector-deployment.yaml
@@ -4,15 +4,10 @@ kind: Deployment
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: pii-detector-deployment
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -21,16 +16,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- with .Values.global.commonLabels }}
-          {{- toYaml . | nindent 4 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        {{ include "shared_labels" . | nindent 8 }}
+        {{ include "shared_pod_labels" . | nindent 8 }}
+        app.kubernetes.io/component: pii-detector
         app: {{ template "otterize.piidetector.fullName" . }}
       annotations:
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 4 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.piidetector.fullName" . }}
       {{- with .Values.piidetector.tolerations }}

--- a/network-mapper/templates/pii-detector-service.yaml
+++ b/network-mapper/templates/pii-detector-service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-service
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.piidetector.fullName" . }}

--- a/network-mapper/templates/pii-detector-service.yaml
+++ b/network-mapper/templates/pii-detector-service.yaml
@@ -3,15 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: pii-detector-service
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.piidetector.fullName" . }}

--- a/network-mapper/templates/pii-detector-service.yaml
+++ b/network-mapper/templates/pii-detector-service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-service
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.piidetector.fullName" . }}

--- a/network-mapper/templates/pii-detector-service.yaml
+++ b/network-mapper/templates/pii-detector-service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-service
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "otterize.piidetector.fullName" . }}

--- a/network-mapper/templates/pii-detector-serviceaccount.yaml
+++ b/network-mapper/templates/pii-detector-serviceaccount.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-serviceaccount
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 {{ end }}

--- a/network-mapper/templates/pii-detector-serviceaccount.yaml
+++ b/network-mapper/templates/pii-detector-serviceaccount.yaml
@@ -4,13 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: pii-detector-serviceaccount
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 {{ end }}

--- a/network-mapper/templates/pii-detector-serviceaccount.yaml
+++ b/network-mapper/templates/pii-detector-serviceaccount.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-serviceaccount
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 {{ end }}

--- a/network-mapper/templates/pii-detector-serviceaccount.yaml
+++ b/network-mapper/templates/pii-detector-serviceaccount.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.piidetector.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: pii-detector-serviceaccount
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 {{ end }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -4,10 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: sniffer-daemonset
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: sniffer
         app: {{ template "otterize.sniffer.fullName" . }}
       annotations:
-        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.sniffer.fullName" . }}
     {{- if .Values.sniffer.podSecurityContext }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -4,10 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: sniffer-daemonset
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "otterize.networkMapper.shared_labels" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_labels" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: sniffer
         app: {{ template "otterize.sniffer.fullName" . }}
       annotations:
-        {{ include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
-        {{ include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_annotations" . | nindent 8 }}
+        {{- include "otterize.networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.sniffer.fullName" . }}
     {{- if .Values.sniffer.podSecurityContext }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -4,10 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: sniffer-daemonset
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -15,13 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{ include "shared_labels" . | nindent 8 }}
-        {{ include "shared_pod_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_labels" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_labels" . | nindent 8 }}
         app.kubernetes.io/component: sniffer
         app: {{ template "otterize.sniffer.fullName" . }}
       annotations:
-        {{ include "shared_annotations" . | nindent 8 }}
-        {{ include "shared_pod_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_annotations" . | nindent 8 }}
+        {{ include "networkMapper.shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.sniffer.fullName" . }}
     {{- if .Values.sniffer.podSecurityContext }}

--- a/network-mapper/templates/sniffer-daemonset.yaml
+++ b/network-mapper/templates/sniffer-daemonset.yaml
@@ -4,15 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: sniffer-daemonset
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -20,22 +15,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- with .Values.global.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{ include "shared_labels" . | nindent 8 }}
+        {{ include "shared_pod_labels" . | nindent 8 }}
+        app.kubernetes.io/component: sniffer
         app: {{ template "otterize.sniffer.fullName" . }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
       annotations:
-        {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.global.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        app.kubernetes.io/version: {{ .Chart.Version }}
+        {{ include "shared_annotations" . | nindent 8 }}
+        {{ include "shared_pod_annotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "otterize.sniffer.fullName" . }}
     {{- if .Values.sniffer.podSecurityContext }}

--- a/network-mapper/templates/sniffer-role.yaml
+++ b/network-mapper/templates/sniffer-role.yaml
@@ -3,10 +3,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-rolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,10 +21,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-role
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -61,10 +61,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-network-sniffer-scc-role
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-scc-role
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -77,10 +77,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-sniffer-scc-rolebinding
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-scc-rolebinding
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/sniffer-role.yaml
+++ b/network-mapper/templates/sniffer-role.yaml
@@ -3,10 +3,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,10 +21,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-role
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -60,6 +60,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-network-sniffer-scc-role
+  labels:
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-sniffer-scc-role
+  annotations:
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -72,10 +77,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-sniffer-scc-rolebinding
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-scc-rolebinding
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/sniffer-role.yaml
+++ b/network-mapper/templates/sniffer-role.yaml
@@ -3,10 +3,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-rolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,10 +21,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-role
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -61,10 +61,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otterize-network-sniffer-scc-role
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-scc-role
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
@@ -77,10 +77,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-sniffer-scc-rolebinding
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-scc-rolebinding
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/sniffer-role.yaml
+++ b/network-mapper/templates/sniffer-role.yaml
@@ -3,15 +3,10 @@ kind: RoleBinding
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-sniffer-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -26,15 +21,10 @@ kind: Role
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-sniffer-role
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 rules:
   - apiGroups:
       - ''
@@ -82,15 +72,10 @@ kind: RoleBinding
 metadata:
   name: otterize-network-sniffer-scc-rolebinding
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-sniffer-scc-rolebinding
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/network-mapper/templates/sniffer-securitycontextconstraints.yaml
+++ b/network-mapper/templates/sniffer-securitycontextconstraints.yaml
@@ -3,10 +3,10 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: otterize-network-sniffer-scc
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
     kubernetes.io/description: 'otterize-network-sniffer-scc allows the Otterize network sniffers to capture traffic on their host nodes,
     as well as read /proc in order to match traffic with pods. For this, allowHostDirVolumePlugin, allowHostNetwork, allowHostPID, and the capabilities SYS_PTRACE and NET_RAW are required.'
     release.openshift.io/create-only: "true"

--- a/network-mapper/templates/sniffer-securitycontextconstraints.yaml
+++ b/network-mapper/templates/sniffer-securitycontextconstraints.yaml
@@ -2,7 +2,11 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
+  labels:
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: otterize-network-sniffer-scc
   annotations:
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
     kubernetes.io/description: 'otterize-network-sniffer-scc allows the Otterize network sniffers to capture traffic on their host nodes,
     as well as read /proc in order to match traffic with pods. For this, allowHostDirVolumePlugin, allowHostNetwork, allowHostPID, and the capabilities SYS_PTRACE and NET_RAW are required.'
     release.openshift.io/create-only: "true"

--- a/network-mapper/templates/sniffer-securitycontextconstraints.yaml
+++ b/network-mapper/templates/sniffer-securitycontextconstraints.yaml
@@ -3,10 +3,10 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: otterize-network-sniffer-scc
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
     kubernetes.io/description: 'otterize-network-sniffer-scc allows the Otterize network sniffers to capture traffic on their host nodes,
     as well as read /proc in order to match traffic with pods. For this, allowHostDirVolumePlugin, allowHostNetwork, allowHostPID, and the capabilities SYS_PTRACE and NET_RAW are required.'
     release.openshift.io/create-only: "true"

--- a/network-mapper/templates/sniffer-serviceaccount.yaml
+++ b/network-mapper/templates/sniffer-serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "networkMapper.shared_labels" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-serviceaccount
   annotations:
-    {{ include "networkMapper.shared_annotations" . | nindent 4 }}
+    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}

--- a/network-mapper/templates/sniffer-serviceaccount.yaml
+++ b/network-mapper/templates/sniffer-serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "otterize.networkMapper.shared_labels" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-serviceaccount
   annotations:
-    {{ include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
+    {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}

--- a/network-mapper/templates/sniffer-serviceaccount.yaml
+++ b/network-mapper/templates/sniffer-serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{ include "shared_labels" . | nindent 4 }}
+    {{ include "networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-sniffer-serviceaccount
   annotations:
-    {{ include "shared_annotations" . | nindent 4 }}
+    {{ include "networkMapper.shared_annotations" . | nindent 4 }}

--- a/network-mapper/templates/sniffer-serviceaccount.yaml
+++ b/network-mapper/templates/sniffer-serviceaccount.yaml
@@ -3,12 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "otterize.sniffer.fullName" . }}
   labels:
-    {{- with .Values.global.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_labels" . | nindent 4 }}
+    app.kubernetes.io/component: network-sniffer-serviceaccount
   annotations:
-    {{- with .Values.global.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    app.kubernetes.io/version: {{ .Chart.Version }}
+    {{ include "shared_annotations" . | nindent 4 }}

--- a/otterize-kubernetes/Chart.yaml
+++ b/otterize-kubernetes/Chart.yaml
@@ -13,12 +13,6 @@ dependencies:
     alias: credentialsOperator
     version: ">= 0.0.1"
     repository: file://./../credentials-operator
-  - name: spire
-    alias: spire
-    version: "1.0.0"
-    # condition must have NO spaces or the values are considered invalid and will make this always be true! DO NOT add spaces around the comma!
-    condition: deployment.spire,global.deployment.spire
-    repository: file://./../spire
   - name: intents-operator
     alias: intentsOperator
     version: ">= 0.1.2"


### PR DESCRIPTION
### Description
This PR adds standard `app. kubernetes.io` labels to all components deployed as part of the otterize-kubernetes helm chart, including: 
- `app.kubernetes.io/name: credentials-operator/intents-operator/network-mapper`
- `app.kubernetes.io/part-of: otterize`
- `app.kubernetes.io/version: {{ .Chart.Version }}`
- `app.kubernetes.io/component`: the particular component

These standard labels are commonly used by external tools (such as datadog) and can be used for better monitoring & visualization. 


### References
- https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
