### PR TITLE
Fix bug where Azure & AWS IAM identities are not created due to broken validating/mutating webhook configurations

### DIFF
--- a/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-aws-mutating-webhook-configuration.yaml
@@ -6,7 +6,8 @@ metadata:
   name: otterize-credentials-operator-aws-mutating-webhook-configuration
   labels:
     {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
-    app.kubernetes.io/component: credentials-operator-aws-mutating-webhook
+    # This should technically be named "credentials-operator-aws-mutating-webhook", but the current component name is used to identify the webhook in ValidatingWebhookConfigsReconciler.
+    app.kubernetes.io/component: credentials-operator
   annotations:
     {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:

--- a/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
   name: otterize-credentials-operator-azure-mutating-webhook-configuration
   labels:
     {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
-    # TODO: this needs to be changed to  credentials-operator-azure-mutating-webhook, but the current component name is used to identify the webhook in our ValidatingWebhookConfigsReconciler.
+    # This should technically be named "credentials-azure-aws-mutating-webhook", but the current component name is used to identify the webhook in ValidatingWebhookConfigsReconciler.
     app.kubernetes.io/component: credentials-operator
   annotations:
     {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}

--- a/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
+++ b/credentials-operator/templates/credentials-operator-azure-mutating-webhook-configuration.yaml
@@ -6,7 +6,8 @@ metadata:
   name: otterize-credentials-operator-azure-mutating-webhook-configuration
   labels:
     {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
-    app.kubernetes.io/component: credentials-operator-azure-mutating-webhook
+    # TODO: this needs to be changed to  credentials-operator-azure-mutating-webhook, but the current component name is used to identify the webhook in our ValidatingWebhookConfigsReconciler.
+    app.kubernetes.io/component: credentials-operator
   annotations:
     {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
 webhooks:

--- a/credentials-operator/templates/credentials-operator-deployment.yaml
+++ b/credentials-operator/templates/credentials-operator-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-deployment
+    app: credentials-operator
   annotations:
     {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager

--- a/credentials-operator/templates/credentials-operator-metrics-service.yaml
+++ b/credentials-operator/templates/credentials-operator-metrics-service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-controller-manager-metrics-service
+    app: credentials-operator
   annotations:
     {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-controller-manager-metrics-service

--- a/credentials-operator/templates/credentials-operator-webhook-service.yaml
+++ b/credentials-operator/templates/credentials-operator-webhook-service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "otterize.credentialsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: credentials-operator-webhook-service
+    app: credentials-operator
   annotations:
     {{- include "otterize.credentialsOperator.shared_annotations" . | nindent 4 }}
   name: credentials-operator-webhook-service

--- a/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
+++ b/intents-operator/templates/intents-operator-controller-manager-metrics-service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-metrics-service
+    app: intents-operator
   annotations:
     {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager-metrics-service

--- a/intents-operator/templates/intents-operator-deployment.yaml
+++ b/intents-operator/templates/intents-operator-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-controller-manager-deployment
+    app: intents-operator
   annotations:
     {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-controller-manager

--- a/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
+++ b/intents-operator/templates/intents-operator-webhook-server-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: intents-operator-webhook-server-deployment
+    app: intents-operator-webhook-server
   annotations:
     {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: intents-operator-webhook-server

--- a/intents-operator/templates/otterize-validating-webhook-configuration.yaml
+++ b/intents-operator/templates/otterize-validating-webhook-configuration.yaml
@@ -6,7 +6,8 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
-    app.kubernetes.io/component: intents-operator-webhook-configmap
+    # This should technically be named "intents-operator-webhook-configmapn", but the current component name is used to identify the webhook in ValidatingWebhookConfigsReconciler.
+    app.kubernetes.io/component: intents-operator
   annotations:
     {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-webhook-configmap
@@ -16,7 +17,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     {{- include "otterize.intentsOperator.shared_labels" . | nindent 4 }}
-    app.kubernetes.io/component: intents-operator-validating-webhook-configuration
+    # This should technically be named "intents-operator-validating-webhook-configuration", but the current component name is used to identify the webhook in ValidatingWebhookConfigsReconciler.
+    app.kubernetes.io/component: intents-operator
   annotations:
     {{- include "otterize.intentsOperator.shared_annotations" . | nindent 4 }}
   name: otterize-validating-webhook-configuration

--- a/network-mapper/templates/mapper-webhook-service.yaml
+++ b/network-mapper/templates/mapper-webhook-service.yaml
@@ -25,6 +25,7 @@ metadata:
   labels:
     {{- include "otterize.networkMapper.shared_labels" . | nindent 4 }}
     app.kubernetes.io/component: network-mapper-webhook-network-policy
+    app: otterize-network-mapper
   annotations:
     {{- include "otterize.networkMapper.shared_annotations" . | nindent 4 }}
 spec:


### PR DESCRIPTION
### Description
This PR fixes a bug caused by https://github.com/otterize/helm-charts/pull/304, causing Azure & AWS admission webhooks to fail on pod admission. This was caused by changing the value of the `app.kubernetes.io/component` label on the webhook configurations, which caused the webhook reconciliation process to miss them. 

### References
- https://github.com/otterize/helm-charts/pull/304

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
