### PR TITLE
Add required permission for network mapper to report webhook service to Otterize cloud

### DIFF
--- a/network-mapper/templates/mapper-clusterrole.yaml
+++ b/network-mapper/templates/mapper-clusterrole.yaml
@@ -92,8 +92,23 @@ rules:
     verbs:
       - get
       - list
-      - patch
-      - update
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
 {{ if or (and (eq .Values.global.allowGetAllResources nil) .Values.allowGetAllResources) .Values.global.allowGetAllResources}}
   - apiGroups:
       - '*'


### PR DESCRIPTION
### Description

In order to support the auto-allow-webhook-traffic on Otterize cloud, the mapper needs to report which services are backed by a webhook. For this, the network mapper needs to monitor all kind of webhooks.


### References

- [Network mapper](https://github.com/otterize/network-mapper/pull/303)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
