### PR TITLE
Increase the tests timeout when installing Otterize

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   test-chart-deployment:
-    timeout-minutes: 5
+    timeout-minutes: 8
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/tests/base_suite.go
+++ b/tests/base_suite.go
@@ -162,7 +162,7 @@ func (s *BaseSuite) InstallOtterizeHelmChart(values map[string]any) {
 	installAction.ReleaseName = OtterizeHelmReleaseName
 	installAction.CreateNamespace = true
 	installAction.Wait = true
-	installAction.Timeout = 2 * time.Minute
+	installAction.Timeout = 5 * time.Minute
 
 	// Run helm install command
 	logrus.WithField("values", values).WithField("namespace", OtterizeNamespace).Info("Installing otterize helm chart")


### PR DESCRIPTION
### Description

The tests are failing due to timeouts. Inscreasing installation timeout.


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
