### PR TITLE
Revert intents-operator chart to use appVersion v3.0.15

### DIFF
--- a/intents-operator/Chart.yaml
+++ b/intents-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: intents-operator
 description: Otterize intents operator
 type: application
 version: 4.0.25
-appVersion: v3.0.16
+appVersion: v3.0.15
 home: https://github.com/otterize/intents-operator
 sources:
   - https://github.com/otterize/intents-operator


### PR DESCRIPTION


### Description

Due to a bug detected in v3.0.16 reverting to v3.0.15 until we release a bug fix.

